### PR TITLE
Migrate the message dispatcher and the events handler from `Gaia` to `Engine`

### DIFF
--- a/src/gaia/main.py
+++ b/src/gaia/main.py
@@ -40,49 +40,9 @@ class Gaia:
         self.logger.info("Initializing Gaia")
         self.started: bool = False
         self.engine = Engine()
-        self._message_broker: "KombuDispatcher" | None = None
         self._db: "SQLAlchemyWrapper" | None = None
         if self._config.USE_DATABASE:
             self._init_database()
-        if self._config.COMMUNICATE_WITH_OURANOS:
-            broker_url = config_cls.AGGREGATOR_COMMUNICATION_URL
-            broker_type = broker_url[:broker_url.index("://")]
-            if broker_type not in {"amqp", "redis"}:
-                raise ValueError(f"{broker_type} is not supported")
-            self._init_message_broker()
-
-    def _init_message_broker(self) -> None:
-        self.logger.info("Initialising the message broker")
-        broker_url = self._config.AGGREGATOR_COMMUNICATION_URL
-        self.logger.debug("Initializing the dispatcher")
-        if broker_url == "amqp://":
-            broker_url = "amqp://guest:guest@localhost:5672//"
-        elif broker_url == "redis://":
-            broker_url = "redis://localhost:6379/0"
-        try:
-            from dispatcher import KombuDispatcher
-        except ImportError:
-            raise RuntimeError(
-                "Event-dispatcher is required to use the dispatcher. Download it "
-                "from `https://github.com/vaamb/dispatcher` and install it in "
-                "your virtual env"
-            )
-        self.message_broker = KombuDispatcher(
-            "gaia", url=broker_url, queue_options={
-                "name": f"gaia-{self._config.ENGINE_UID}",
-                # Delete the queue after one week, CRUD requests will be lost
-                #  at this point
-                "expires": 60 * 60 * 24 * 7
-            })
-        from gaia.events import Events
-        events_handler = Events(engine=self.engine)
-        self.message_broker.register_event_handler(events_handler)
-        self.engine.event_handler = events_handler
-
-    def _start_message_broker(self) -> None:
-        self.message_broker: "KombuDispatcher"
-        self.logger.info("Starting the dispatcher")
-        self.message_broker.start(retry=True, block=False)
 
     def _init_database(self) -> None:
         self.logger.info("Initialising the database")
@@ -97,20 +57,6 @@ class Gaia:
                 kwargs={"scoped_session": self.db.scoped_session, "engine": self.engine},
                 trigger="cron", minute="*", misfire_grace_time=10,
                 id="log_sensors_data")
-
-    @property
-    def message_broker(self) -> "KombuDispatcher":
-        if self._message_broker is None:
-            raise RuntimeError(
-                "'message_broker' is not valid as the message broker between "
-                "Ouranos and Gaia is not used. To use it, set the config "
-                "parameter 'COMMUNICATE_WITH_OURANOS' to True, and the "
-                "parameter 'AGGREGATOR_COMMUNICATION_URL' to a valid url")
-        return self._message_broker
-
-    @message_broker.setter
-    def message_broker(self, value: "KombuDispatcher" | None) -> None:
-        self._message_broker = value
 
     @property
     def db(self) -> "SQLAlchemyWrapper":
@@ -133,8 +79,6 @@ class Gaia:
             self.logger.info("Starting Gaia")
             start_scheduler()
             self.engine.start()
-            if self._config.COMMUNICATE_WITH_OURANOS:
-                self._start_message_broker()
             self.started = True
             self.logger.info("GAIA started successfully")
         else:
@@ -152,8 +96,6 @@ class Gaia:
         if self.started:
             self.logger.info("Stopping")
             self.engine.stop()
-            if self._config.COMMUNICATE_WITH_OURANOS:
-                self.message_broker.stop()
             scheduler = get_scheduler()
             if self.use_db:
                 scheduler.remove_job("log_sensors_data")


### PR DESCRIPTION
- It made little sense to set up `Engine` and the events handler and `Events` in `Gaia` and then pass references to each other as "siblings" while in practice `Events` is the child of `Engine`