### PR TITLE
Explicitly turn down `Switches` and `Dimmer` with `SubroutineTemplate.remove_hardware`

### DIFF
--- a/src/gaia/hardware/abc.py
+++ b/src/gaia/hardware/abc.py
@@ -395,12 +395,6 @@ class gpioHardware(Hardware):
 
 
 class Switch(Hardware):
-    def __del__(self) -> None:
-        try:
-            self.turn_off()
-        except AttributeError:  # Pin not yet setup
-            pass
-
     def turn_on(self) -> None:
         raise NotImplementedError(
             "This method must be implemented in a subclass"
@@ -422,9 +416,6 @@ class Dimmer(Hardware):
                 "address 1 being for the main (on/off) switch and address 2 "
                 "being PWM-able"
             )
-
-    def __del__(self):
-        self.set_pwm_level(0)
 
     def set_pwm_level(self, level) -> None:
         raise NotImplementedError(

--- a/src/gaia/hardware/multiplexers.py
+++ b/src/gaia/hardware/multiplexers.py
@@ -37,7 +37,7 @@ class Multiplexer(metaclass=_MetaMultiplexer):
         self._address: int = i2c_address
         self.device = self._get_device()
 
-    def __del__(self):
+    def __del__(self) -> None:
         str_address = str(self._address)
         del _MetaMultiplexer.instances[str_address]
 

--- a/src/gaia/subroutines/template.py
+++ b/src/gaia/subroutines/template.py
@@ -119,10 +119,17 @@ class SubroutineTemplate(ABC):
             )
 
     def remove_hardware(self, hardware_uid: str) -> None:
-        try:
-            del self.hardware[hardware_uid]
-        except KeyError:
-            self.logger.error(f"Hardware '{hardware_uid}' does not exist")
+        if not self.hardware.get(hardware_uid):
+            self.logger.error(
+                f"Hardware '{hardware_uid}' is not managed by this subroutine"
+            )
+
+        hardware = self.hardware[hardware_uid]
+        if isinstance(hardware, Switch):
+            hardware.turn_off()
+        if isinstance(hardware, Dimmer):
+            hardware.set_pwm_level(0)
+        del self.hardware[hardware_uid]
 
     @abstractmethod
     def get_hardware_needed_uid(self) -> set[str]:


### PR DESCRIPTION
- Remove the `__del__` method from `Switches` and `Dimmer`

- `Switches` and `Dimmer` are already explicitly turned down when they are created with `SubroutineTemplate.add_hardware`