### PR TITLE
Use explicit function setters for `ActuatorHandler`'s `mode` and `status`

### DIFF
--- a/src/gaia/actuator_handler.py
+++ b/src/gaia/actuator_handler.py
@@ -18,6 +18,11 @@ def always_off(**kwargs) -> bool:
 
 
 class ActuatorHandler:
+    __slots__ = (
+        "_expected_status_function", "_time_limit", "_timer_on", "last_mode",
+        "last_status", "subroutine", "type"
+    )
+
     def __init__(
             self,
             subroutine: "SubroutineTemplate",
@@ -29,7 +34,8 @@ class ActuatorHandler:
         self.type = actuator_type
         self._timer_on: bool = False
         self._time_limit: float = 0.0
-        self._expected_status_function: Callable[..., bool] = expected_status_function
+        self._expected_status_function: Callable[..., bool] = \
+            expected_status_function
         self.last_mode: ActuatorMode = self.mode
         self.last_status: bool = self.status
 
@@ -45,8 +51,7 @@ class ActuatorHandler:
     def mode(self) -> ActuatorMode:
         return self.subroutine.ecosystem.actuators_state[self.type.value]["mode"]
 
-    @mode.setter
-    def mode(self, value: ActuatorMode) -> None:
+    def set_mode(self, value: ActuatorMode) -> None:
         self._set_mode_no_update(value)
         if self.mode != self.last_mode:
             self.subroutine.logger.info(
@@ -62,14 +67,12 @@ class ActuatorHandler:
     def status(self) -> bool:
         return self.subroutine.ecosystem.actuators_state[self.type.value]["status"]
 
-    @status.setter
-    def status(self, value: bool) -> None:
+    def set_status(self, value: bool) -> None:
         self._set_status_no_update(value)
         if self.status != self.last_status:
             self.subroutine.logger.info(
                 f"{self.type.value.capitalize()} has been turned "
                 f"{'on' if self.status else 'off'}")
-            self.send_actuators_state()
             self.last_status = self.status
 
     def _set_status_no_update(self, value: bool) -> None:
@@ -156,7 +159,7 @@ class ActuatorHandler:
     def compute_expected_status(self, **kwargs) -> bool:
         countdown = self.countdown
         if countdown is not None and countdown <= 0.1:
-            self.mode = ActuatorMode.automatic
+            self.set_mode(ActuatorMode.automatic)
             self.reset_countdown()
         if self.mode == ActuatorMode.automatic:
             return self._expected_status_function(**kwargs)

--- a/src/gaia/subroutines/climate.py
+++ b/src/gaia/subroutines/climate.py
@@ -286,7 +286,7 @@ class Climate(SubroutineTemplate):
                 actuator_handler: ActuatorHandler,
                 pid_output: float
         ) -> None:
-            actuator_handler.status = True
+            actuator_handler.set_status(True)
             actuator_list = cast(
                 list[Switch],
                 Hardware.get_actives_by_type(actuator_handler.type.value).values())
@@ -296,7 +296,7 @@ class Climate(SubroutineTemplate):
                     actuator.set_pwm_level(pid_output)
 
         def deactivate(actuator_handler: ActuatorHandler) -> None:
-            actuator_handler.status = False
+            actuator_handler.set_status(False)
             actuator_list = cast(
                 list[Switch],
                 Hardware.get_actives_by_type(actuator_handler.type.value).values())

--- a/src/gaia/subroutines/light.py
+++ b/src/gaia/subroutines/light.py
@@ -95,12 +95,12 @@ class Light(SubroutineTemplate):
             # Reset pid so there is no internal value overshoot
             if not self.actuator.last_status:
                 self._pid.reset()
-            self.actuator.status = True
+            self.actuator.set_status(True)
             for light in self.hardware.values():
                 light.turn_on()
         # If lighting == False, lights should be off
         else:
-            self.actuator.status = False
+            self.actuator.set_status(False)
             for light in self.hardware.values():
                 light.turn_off()
 


### PR DESCRIPTION
Those setters trigger `send_actuators_state`, which has side effects