### PR TITLE
Use `WeakValueDictionary` to store singleton instances

### DIFF
--- a/src/gaia/engine.py
+++ b/src/gaia/engine.py
@@ -42,7 +42,7 @@ class Engine(metaclass=SingletonMeta):
     When used within Gaia, the Engine is automatically instantiated when needed.
     """
     def __init__(self) -> None:
-        self._config: EngineConfig = weakref.proxy(EngineConfig())
+        self._config: EngineConfig = EngineConfig()
         self._config.engine = self
         self.gaia_config: Type[GaiaConfig] = get_config()
         configure_logging(self.gaia_config)

--- a/src/gaia/hardware/abc.py
+++ b/src/gaia/hardware/abc.py
@@ -10,6 +10,7 @@ import textwrap
 import typing as t
 from typing import Any, Literal, Self, Type
 import weakref
+from weakref import WeakValueDictionary
 
 from gaia_validators import (
     safe_enum_from_name, HardwareConfig, HardwareLevel, HardwareLevelNames,
@@ -174,7 +175,7 @@ class Address:
 
 
 class _MetaHardware(type):
-    instances: dict[str, "Hardware"] = {}
+    instances: dict[str, "Hardware"] = WeakValueDictionary()
 
     def __call__(cls, *args, **kwargs) -> "Hardware":
         uid = kwargs["uid"]
@@ -208,8 +209,8 @@ class Hardware(metaclass=_MetaHardware):
     ecosystems.cfg
     """
     __slots__ = (
-        "_subroutine", "_uid", "_name", "_address_book", "_level", "_type",
-        "_model", "_measures", "_multiplexer_model", "_plants"
+        "__weakref__", "_subroutine", "_uid", "_name", "_address_book",
+        "_level", "_type", "_model", "_measures", "_multiplexer_model", "_plants"
     )
 
     def __init__(
@@ -247,12 +248,6 @@ class Hardware(metaclass=_MetaHardware):
             plants = [plants]
         self._plants = plants or []
         self._multiplexer_model = multiplexer_model
-
-    def __del__(self) -> None:
-        # If an error arises during __init__ (because of a missing package), no
-        #  instance will be registered
-        if _MetaHardware.instances.get(self._uid):
-            del _MetaHardware.instances[self._uid]
 
     def __repr__(self) -> str:
         return (

--- a/src/gaia/hardware/multiplexers.py
+++ b/src/gaia/hardware/multiplexers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing as t
 from typing import Any
+from weakref import WeakValueDictionary
 
 import busio
 
@@ -14,7 +15,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 
 class _MetaMultiplexer(type):
-    instances: dict[str, "Multiplexer"] = {}
+    instances: dict[str, "Multiplexer"] = WeakValueDictionary()
 
     def __call__(cls, *args, **kwargs) -> "Multiplexer":
         address: int = kwargs["address"]
@@ -36,10 +37,6 @@ class Multiplexer(metaclass=_MetaMultiplexer):
             self._i2c = i2c
         self._address: int = i2c_address
         self.device = self._get_device()
-
-    def __del__(self) -> None:
-        str_address = str(self._address)
-        del _MetaMultiplexer.instances[str_address]
 
     def _get_device(self) -> Any:
         raise NotImplementedError(

--- a/src/gaia/utils.py
+++ b/src/gaia/utils.py
@@ -10,6 +10,7 @@ import os
 import platform
 import socket
 from typing import Any
+from weakref import WeakValueDictionary
 
 import ruamel.yaml
 from ruamel.yaml import SafeRepresenter, ScalarNode
@@ -443,7 +444,7 @@ def configure_logging(config_class):
 
 
 class SingletonMeta(type):
-    _instances: dict[type, type] = {}
+    _instances: dict[type, type] = WeakValueDictionary()
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:


### PR DESCRIPTION
- Remove the non-working `__del__` methods associated with singleton instance destruction