### PR TITLE
Reuse `Sensors`'`ThreadPoolExecutor`

### DIFF
--- a/src/gaia/engine.py
+++ b/src/gaia/engine.py
@@ -8,7 +8,6 @@ from threading import Event, Thread
 from time import sleep
 import typing as t
 from typing import Type
-import weakref
 
 from gaia.config import (
     EngineConfig, GaiaConfig, get_cache_dir, get_config, get_ecosystem_IDs)
@@ -228,6 +227,7 @@ class Engine(metaclass=SingletonMeta):
                 get_virtual_ecosystem(ecosystem_uid, start=True)
 
     def _loop(self) -> None:
+        self.refresh_ecosystems()
         while True:
             with self.config.new_config:
                 self.config.new_config.wait()
@@ -496,7 +496,6 @@ class Engine(metaclass=SingletonMeta):
         self.thread = Thread(
             target=self._loop,
             name="engine")
-        self.refresh_ecosystems()
         self._started_event.set()
         self.thread.start()
         self.logger.info("Gaia started")
@@ -521,6 +520,7 @@ class Engine(metaclass=SingletonMeta):
         # Stop plugins and background tasks
         self.stop_plugins()
         self.stop_background_tasks()
+        self.config.stop_watchdog()
         self.logger.info("Gaia has stopped")
 
     def wait(self):

--- a/src/gaia/subroutines/sensors.py
+++ b/src/gaia/subroutines/sensors.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from statistics import mean
 from threading import Event, Lock, Thread
@@ -116,12 +115,11 @@ class Sensors(SubroutineTemplate):
         to_average: dict[str, list[float]] = {}
         cache["timestamp"] = datetime.now(timezone.utc).replace(microsecond=0)
         cache["records"] = []
-        with ThreadPoolExecutor() as executor:
-            futures = [
-                executor.submit(hardware.get_data)
-                for hardware in self.hardware.values()
-            ]
-            sensors_data = [future.result() for future in futures]
+        futures = [
+            self.executor.submit(hardware.get_data)
+            for hardware in self.hardware.values()
+        ]
+        sensors_data = [future.result() for future in futures]
         for sensor in sensors_data:
             cache["records"].extend(
                 sensor_record for sensor_record in sensor


### PR DESCRIPTION
- Share the executor for all the subroutines of a same ecosystem

- Reorder thread creation as config > plugins > engine > ecosystems (and the opposite at destruction)