### PR TITLE
Add an `engine` variable to `EngineConfig`'s init

### DIFF
--- a/src/gaia/config/from_files.py
+++ b/src/gaia/config/from_files.py
@@ -127,12 +127,18 @@ class EngineConfig(metaclass=SingletonMeta):
     To interact with a specific ecosystem configuration, the EcosystemConfig
     class should be used.
     """
-    def __init__(self, base_dir: Path | None = None) -> None:
+    def __init__(
+            self,
+            engine: "Engine" | None = None,
+            base_dir: Path | None = None
+    ) -> None:
         self.logger = logging.getLogger("gaia.engine.config")
         self.logger.debug("Initializing EngineConfig")
         base_dir = base_dir or get_base_dir()
         self._base_dir = Path(base_dir)
         self._engine: "Engine" | None = None
+        if engine:
+            self.engine = engine
         self._ecosystems_config: dict = {}
         self._private_config: dict = {}
         self._sun_times: gv.SunTimes | None = None

--- a/src/gaia/engine.py
+++ b/src/gaia/engine.py
@@ -42,8 +42,7 @@ class Engine(metaclass=SingletonMeta):
     When used within Gaia, the Engine is automatically instantiated when needed.
     """
     def __init__(self) -> None:
-        self._config: EngineConfig = EngineConfig()
-        self._config.engine = self
+        self._config: EngineConfig = EngineConfig(self)
         self.gaia_config: Type[GaiaConfig] = get_config()
         configure_logging(self.gaia_config)
         self.logger: logging.Logger = logging.getLogger(f"gaia.engine")


### PR DESCRIPTION
- Makes `Engine` init cleaner