### PR TITLE
Revert "Add an `engine` variable to `EngineConfig`'s init (#37)"

### DIFF
--- a/src/gaia/config/from_files.py
+++ b/src/gaia/config/from_files.py
@@ -127,18 +127,12 @@ class EngineConfig(metaclass=SingletonMeta):
     To interact with a specific ecosystem configuration, the EcosystemConfig
     class should be used.
     """
-    def __init__(
-            self,
-            engine: "Engine" | None = None,
-            base_dir: Path | None = None
-    ) -> None:
+    def __init__(self, base_dir: Path | None = None) -> None:
         self.logger = logging.getLogger("gaia.engine.config")
         self.logger.debug("Initializing EngineConfig")
         base_dir = base_dir or get_base_dir()
         self._base_dir = Path(base_dir)
         self._engine: "Engine" | None = None
-        if engine:
-            self.engine = engine
         self._ecosystems_config: dict = {}
         self._private_config: dict = {}
         self._sun_times: gv.SunTimes | None = None

--- a/src/gaia/engine.py
+++ b/src/gaia/engine.py
@@ -42,7 +42,8 @@ class Engine(metaclass=SingletonMeta):
     When used within Gaia, the Engine is automatically instantiated when needed.
     """
     def __init__(self) -> None:
-        self._config: EngineConfig = EngineConfig(self)
+        self._config: EngineConfig = EngineConfig()
+        self._config.engine = self
         self.gaia_config: Type[GaiaConfig] = get_config()
         configure_logging(self.gaia_config)
         self.logger: logging.Logger = logging.getLogger(f"gaia.engine")


### PR DESCRIPTION
This reverts commit cf2ea050f1ac648c3e928f2c410b41f34b68653e.

- `Engine` would not be linked to `EngineConfig` if called after it