### PR TITLE
Move `GaiaConfig` inside `EngineConfig`

### DIFF
--- a/src/gaia/__init__.py
+++ b/src/gaia/__init__.py
@@ -5,7 +5,7 @@ import typing as t
 
 if t.TYPE_CHECKING:
     from gaia.config import (
-        EcosystemConfig, EngineConfig, get_config)
+        EcosystemConfig, EngineConfig, get_config, set_config)
     from gaia.ecosystem import Ecosystem
     from gaia.engine import Engine
     from gaia.main import main
@@ -16,7 +16,8 @@ else:
     from gaia.main import main
 
     def __getattr__(name):
-        if name in ("EcosystemConfig", "EngineConfig", "get_config"):
+        if name in (
+                "EcosystemConfig", "EngineConfig", "get_config", "set_config"):
             return getattr(import_module("gaia.config"), name)
         if name == "Ecosystem":
             return getattr(import_module("gaia.ecosystem"), name)

--- a/src/gaia/__init__.py
+++ b/src/gaia/__init__.py
@@ -5,7 +5,7 @@ import typing as t
 
 if t.TYPE_CHECKING:
     from gaia.config import (
-        EcosystemConfig, EngineConfig, get_base_dir, get_config)
+        EcosystemConfig, EngineConfig, get_config)
     from gaia.ecosystem import Ecosystem
     from gaia.engine import Engine
     from gaia.main import main
@@ -16,8 +16,7 @@ else:
     from gaia.main import main
 
     def __getattr__(name):
-        if name in (
-                "EcosystemConfig", "EngineConfig", "get_base_dir", "get_config"):
+        if name in ("EcosystemConfig", "EngineConfig", "get_config"):
             return getattr(import_module("gaia.config"), name)
         if name == "Ecosystem":
             return getattr(import_module("gaia.ecosystem"), name)

--- a/src/gaia/config/__init__.py
+++ b/src/gaia/config/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from gaia.config._utils import configure_logging, GaiaConfig, get_config
+from gaia.config._utils import (
+    configure_logging, GaiaConfig, get_config,set_config)
 from gaia.config.base import BaseConfig
 from gaia.config.from_files import (
     EcosystemConfig, EngineConfig, get_IDs as get_ecosystem_IDs)

--- a/src/gaia/config/__init__.py
+++ b/src/gaia/config/__init__.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from gaia.config._utils import (
-    configure_logging, GaiaConfig, get_base_dir, get_cache_dir, get_config,
-    get_log_dir)
-from gaia.config.base import BaseConfig, DIR
+from gaia.config._utils import configure_logging, GaiaConfig, get_config
+from gaia.config.base import BaseConfig
 from gaia.config.from_files import (
     EcosystemConfig, EngineConfig, get_IDs as get_ecosystem_IDs)

--- a/src/gaia/config/_utils.py
+++ b/src/gaia/config/_utils.py
@@ -52,25 +52,25 @@ def get_config() -> Type[GaiaConfig]:
 
 
 def configure_logging(config_class: Type[GaiaConfig]):
-    DEBUG = config_class.DEBUG
-    LOG_TO_STDOUT = config_class.LOG_TO_STDOUT
-    LOG_TO_FILE = config_class.LOG_TO_FILE
-    LOG_ERROR = config_class.LOG_ERROR
+    debug = config_class.DEBUG
+    log_to_stdout = config_class.LOG_TO_STDOUT
+    log_to_file = config_class.LOG_TO_FILE
+    log_error = config_class.LOG_ERROR
 
     log_dir = Path(config_class.LOG_DIR)
 
     handlers = []
 
-    if LOG_TO_STDOUT:
+    if log_to_stdout:
         handlers.append("streamHandler")
 
-    if LOG_TO_FILE:
+    if log_to_file:
         handlers.append("fileHandler")
 
-    if LOG_ERROR:
+    if log_error:
         handlers.append("errorFileHandler")
 
-    LOGGING_CONFIG = {
+    logging_config = {
         "version": 1,
         "disable_existing_loggers": False,
 
@@ -78,7 +78,7 @@ def configure_logging(config_class: Type[GaiaConfig]):
             "streamFormat": {
                 "format": (
                     "%(asctime)s %(levelname)-4.4s [%(filename)-20.20s:%(lineno)3d] %(name)-35.35s: %(message)s"
-                    if DEBUG else
+                    if debug else
                     "%(asctime)s %(levelname)-4.4s %(name)-35.35s: %(message)s"
                 ),
                 "datefmt": "%Y-%m-%d %H:%M:%S"
@@ -91,12 +91,12 @@ def configure_logging(config_class: Type[GaiaConfig]):
 
         "handlers": {
             "streamHandler": {
-                "level": f"{'DEBUG' if DEBUG else 'INFO'}",
+                "level": f"{'DEBUG' if debug else 'INFO'}",
                 "formatter": "streamFormat",
                 "class": "logging.StreamHandler",
             },
             "fileHandler": {
-                "level": f"{'DEBUG' if DEBUG else 'INFO'}",
+                "level": f"{'DEBUG' if debug else 'INFO'}",
                 "formatter": "fileFormat",
                 "class": "logging.handlers.RotatingFileHandler",
                 'filename': f"{log_dir/'base.log'}",
@@ -116,19 +116,19 @@ def configure_logging(config_class: Type[GaiaConfig]):
         "loggers": {
             "": {
                 "handlers": handlers,
-                "level": f"{'DEBUG' if DEBUG else 'INFO'}"
+                "level": f"{'DEBUG' if debug else 'INFO'}"
             },
             "apscheduler": {
                 "handlers": handlers,
-                "level": f"{'DEBUG' if DEBUG else 'WARNING'}"
+                "level": f"{'DEBUG' if debug else 'WARNING'}"
             },
             "engineio": {
                 "handlers": handlers,
-                "level": f"{'DEBUG' if DEBUG else 'INFO'}"
+                "level": f"{'DEBUG' if debug else 'INFO'}"
             },
             "dispatcher": {
                 "handlers": handlers,
-                "level": f"{'DEBUG' if DEBUG else 'WARNING'}"
+                "level": f"{'DEBUG' if debug else 'WARNING'}"
             },
             "urllib3": {
                 "handlers": handlers,
@@ -136,4 +136,4 @@ def configure_logging(config_class: Type[GaiaConfig]):
             },
         },
     }
-    logging.config.dictConfig(LOGGING_CONFIG)
+    logging.config.dictConfig(logging_config)

--- a/src/gaia/config/_utils.py
+++ b/src/gaia/config/_utils.py
@@ -44,10 +44,11 @@ def _get_config() -> Type[GaiaConfig]:
     return GaiaConfig
 
 
-def get_config() -> Type[GaiaConfig]:
+def get_config() -> GaiaConfig:
     global _config
     if _config is None:
-        _config = _get_config()
+        config = _get_config()
+        _config = config()
     return _config
 
 
@@ -55,11 +56,11 @@ def set_config(config: Type[GaiaConfig]) -> None:
     global _config
     if _config is not None:
         raise RuntimeError(
-            "'set_config' cannot be called once 'get_config' is called")
+            "'set_config' cannot be called once 'get_config' has been called")
     _config = config
 
 
-def configure_logging(config_class: Type[GaiaConfig]):
+def configure_logging(config_class: GaiaConfig):
     debug = config_class.DEBUG
     log_to_stdout = config_class.LOG_TO_STDOUT
     log_to_file = config_class.LOG_TO_FILE

--- a/src/gaia/config/_utils.py
+++ b/src/gaia/config/_utils.py
@@ -51,6 +51,14 @@ def get_config() -> Type[GaiaConfig]:
     return _config
 
 
+def set_config(config: Type[GaiaConfig]) -> None:
+    global _config
+    if _config is not None:
+        raise RuntimeError(
+            "'set_config' cannot be called once 'get_config' is called")
+    _config = config
+
+
 def configure_logging(config_class: Type[GaiaConfig]):
     debug = config_class.DEBUG
     log_to_stdout = config_class.LOG_TO_STDOUT

--- a/src/gaia/config/_utils.py
+++ b/src/gaia/config/_utils.py
@@ -67,6 +67,8 @@ def configure_logging(config_class: GaiaConfig):
     log_error = config_class.LOG_ERROR
 
     log_dir = Path(config_class.LOG_DIR)
+    if not log_dir.exists():
+        log_dir.mkdir(parents=True)
 
     handlers = []
 

--- a/src/gaia/config/base.py
+++ b/src/gaia/config/base.py
@@ -7,8 +7,14 @@ class BaseConfig:
     TESTING = False
 
     DIR = os.environ.get("GAIA_DIR") or os.getcwd()
-    LOG_DIR = os.environ.get("GAIA_LOG_DIR") or os.path.join(DIR, "logs")
-    CACHE_DIR = os.environ.get("GAIA_CACHE_DIR") or os.path.join(DIR, ".cache")
+
+    @property
+    def LOG_DIR(self):
+        return os.environ.get("GAIA_LOG_DIR") or os.path.join(self.DIR, "logs")
+
+    @property
+    def CACHE_DIR(self):
+        return os.environ.get("GAIA_CACHE_DIR") or os.path.join(self.DIR, ".cache")
 
     LOG_TO_STDOUT = True
     LOG_TO_FILE = True
@@ -18,10 +24,13 @@ class BaseConfig:
     VIRTUALIZATION = os.environ.get("GAIA_VIRTUALIZATION", False)
 
     USE_DATABASE = False
-    SQLALCHEMY_DATABASE_URI = (
-        os.environ.get("GAIA_DATABASE_URI") or
-        "sqlite:///" + os.path.join(DIR, "gaia_data.db")
-    )
+
+    @property
+    def SQLALCHEMY_DATABASE_URI(self):
+        return (
+            os.environ.get("GAIA_DATABASE_URI") or
+            "sqlite:///" + os.path.join(self.DIR, "gaia_data.db")
+        )
 
     COMMUNICATE_WITH_OURANOS = False
     AGGREGATOR_COMMUNICATION_URL = (

--- a/src/gaia/config/base.py
+++ b/src/gaia/config/base.py
@@ -2,13 +2,11 @@ import os
 import uuid
 
 
-DIR = os.environ.get("GAIA_DIR") or os.getcwd()
-
-
 class BaseConfig:
     DEBUG = False
     TESTING = False
 
+    DIR = os.environ.get("GAIA_DIR") or os.getcwd()
     LOG_DIR = os.environ.get("GAIA_LOG_DIR") or os.path.join(DIR, "logs")
     CACHE_DIR = os.environ.get("GAIA_CACHE_DIR") or os.path.join(DIR, ".cache")
 

--- a/src/gaia/config/from_files.py
+++ b/src/gaia/config/from_files.py
@@ -12,7 +12,7 @@ from requests import ConnectionError, Session
 import string
 from threading import Condition, Event, Lock, Thread
 import typing as t
-from typing import Literal, Type, TypedDict
+from typing import Literal, TypedDict
 import weakref
 from weakref import WeakValueDictionary
 
@@ -173,7 +173,7 @@ class EngineConfig(metaclass=SingletonMeta):
         self._engine = weakref.proxy(value)
 
     @property
-    def app_config(self) -> Type[GaiaConfig]:
+    def app_config(self) -> GaiaConfig:
         return self._app_config
 
     def _get_dir(self, dir_name: str) -> Path:

--- a/src/gaia/config/from_files.py
+++ b/src/gaia/config/from_files.py
@@ -22,7 +22,8 @@ from gaia_validators import safe_enum_from_name
 # TODO: move up once compatibility issues are solved
 from pydantic import Field, field_validator, ValidationError  # noqa
 
-from gaia.config._utils import GaiaConfig, get_config as get_gaia_config
+from gaia.config._utils import (
+    configure_logging, GaiaConfig, get_config as get_gaia_config)
 from gaia.exceptions import (
     EcosystemNotFound, HardwareNotFound, UndefinedParameter)
 from gaia.hardware import hardware_models
@@ -130,6 +131,7 @@ class EngineConfig(metaclass=SingletonMeta):
         self.logger = logging.getLogger("gaia.engine.config")
         self.logger.debug("Initializing EngineConfig")
         self._app_config = gaia_config or get_gaia_config()
+        configure_logging(self.app_config)
         self._dirs: dict[str, Path] = {}
         self._engine: "Engine" | None = None
         self._ecosystems_config: dict = {}

--- a/src/gaia/database/routines.py
+++ b/src/gaia/database/routines.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import scoped_session, Session
 
 from gaia_validators import SensorsData
 
-from gaia.config import get_config
 from gaia.database.models import SensorBuffer, SensorRecord
 
 
@@ -14,13 +13,11 @@ if t.TYPE_CHECKING:
     from gaia.engine import Engine
 
 
-sensors_logging_period = get_config().SENSORS_LOGGING_PERIOD
-
-
 def log_sensors_data(
         scoped_session_: Callable[..., scoped_session],
         engine: "Engine"
 ) -> None:
+    sensors_logging_period = engine.config.app_config.SENSORS_LOGGING_PERIOD
     with scoped_session_() as session:
         session: Session
         for ecosystem_uid, ecosystem in engine.ecosystems.items():

--- a/src/gaia/ecosystem.py
+++ b/src/gaia/ecosystem.py
@@ -60,11 +60,19 @@ class Ecosystem:
     :param ecosystem_id: The name or the uid of an ecosystem, as written in
                           'ecosystems.cfg'
     """
-    def __init__(self, ecosystem_id: str, engine: "Engine"):
-        self._config: EcosystemConfig = EcosystemConfig(ecosystem_id)
-        self._uid: str = self._config.uid
-        self._name: str = self._config.name
+    def __init__(
+            self,
+            ecosystem_id: str,
+            engine: "Engine" | None = None
+    ) -> None:
+        if engine is None:
+            from gaia import Engine
+            engine = Engine()
         self._engine: "Engine" = weakref.proxy(engine)
+        self._config: EcosystemConfig = \
+            self.engine.config.get_ecosystem_config(ecosystem_id)
+        self._uid: str = self.config.uid
+        self._name: str = self.config.name
         self.logger: logging.Logger = logging.getLogger(
             f"gaia.engine.{self._name.replace(' ', '_')}")
         self.logger.info("Initializing the ecosystem")

--- a/src/gaia/engine.py
+++ b/src/gaia/engine.py
@@ -9,8 +9,7 @@ from time import sleep
 import typing as t
 from typing import Type
 
-from gaia.config import (
-    configure_logging, EngineConfig, GaiaConfig, get_config, get_ecosystem_IDs)
+from gaia.config import EngineConfig, GaiaConfig, get_config, get_ecosystem_IDs
 from gaia.config.from_files import detach_config
 from gaia.ecosystem import Ecosystem
 from gaia.exceptions import UndefinedParameter
@@ -44,7 +43,6 @@ class Engine(metaclass=SingletonMeta):
         self._config: EngineConfig = EngineConfig()
         self._config.engine = self
         self.gaia_config: Type[GaiaConfig] = get_config()
-        configure_logging(self.gaia_config)
         self.logger: logging.Logger = logging.getLogger(f"gaia.engine")
         self.logger.info("Initializing Gaia")
         self._ecosystems: dict[str, Ecosystem] = {}

--- a/src/gaia/engine.py
+++ b/src/gaia/engine.py
@@ -38,8 +38,8 @@ class Engine(metaclass=SingletonMeta):
     manages the config watchdog and updates the sun times once a day.
     When used within Gaia, the Engine is automatically instantiated when needed.
     """
-    def __init__(self) -> None:
-        self._config: EngineConfig = EngineConfig()
+    def __init__(self, engine_config: EngineConfig | None = None) -> None:
+        self._config: EngineConfig = engine_config or EngineConfig()
         self.config.engine = self
         self.logger: logging.Logger = logging.getLogger(f"gaia.engine")
         self.logger.info("Initializing Gaia")

--- a/src/gaia/engine.py
+++ b/src/gaia/engine.py
@@ -8,7 +8,7 @@ from threading import Event, Thread
 from time import sleep
 import typing as t
 
-from gaia.config import EngineConfig, get_ecosystem_IDs
+from gaia.config import EngineConfig
 from gaia.config.from_files import detach_config
 from gaia.ecosystem import Ecosystem
 from gaia.exceptions import UndefinedParameter
@@ -286,7 +286,7 @@ class Engine(metaclass=SingletonMeta):
         :param start: Whether to immediately start the ecosystem after its
                       creation or not
         """
-        ecosystem_uid, ecosystem_name = get_ecosystem_IDs(ecosystem_id)
+        ecosystem_uid, ecosystem_name = self.config.get_IDs(ecosystem_id)
         if ecosystem_uid not in self.ecosystems:
             ecosystem = Ecosystem(ecosystem_uid, self)
             self.ecosystems[ecosystem_uid] = ecosystem
@@ -306,7 +306,7 @@ class Engine(metaclass=SingletonMeta):
         :param ecosystem_id: The name or the uid of an ecosystem, as written in
                              'ecosystems.cfg'
         """
-        ecosystem_uid, ecosystem_name = get_ecosystem_IDs(ecosystem_id)
+        ecosystem_uid, ecosystem_name = self.config.get_IDs(ecosystem_id)
         if ecosystem_uid in self.ecosystems:
             if ecosystem_uid not in self.ecosystems_started:
                 ecosystem: Ecosystem = self.ecosystems[ecosystem_uid]
@@ -332,7 +332,7 @@ class Engine(metaclass=SingletonMeta):
                          If dismounted, the Ecosystem will need to be recreated
                          before being able to restart.
         """
-        ecosystem_uid, ecosystem_name = get_ecosystem_IDs(ecosystem_id)
+        ecosystem_uid, ecosystem_name = self.config.get_IDs(ecosystem_id)
         if ecosystem_uid in self.ecosystems:
             if ecosystem_uid in self.ecosystems_started:
                 ecosystem = self.ecosystems[ecosystem_uid]
@@ -359,7 +359,7 @@ class Engine(metaclass=SingletonMeta):
         :param detach_config_: Whether to remove the Ecosystem's config from
                                memory or not.
         """
-        ecosystem_uid, ecosystem_name = get_ecosystem_IDs(ecosystem_id)
+        ecosystem_uid, ecosystem_name = self.config.get_IDs(ecosystem_id)
         if ecosystem_uid in self.ecosystems:
             if ecosystem_uid in self.ecosystems_started:
                 raise RuntimeError(
@@ -384,7 +384,7 @@ class Engine(metaclass=SingletonMeta):
         :param ecosystem: The name or the uid of an ecosystem, as written in
                           'ecosystems.cfg'
         """
-        ecosystem_uid, ecosystem_name = get_ecosystem_IDs(ecosystem)
+        ecosystem_uid, ecosystem_name = self.config.get_IDs(ecosystem)
         if ecosystem_uid in self.ecosystems:
             _ecosystem = self.ecosystems[ecosystem_uid]
         else:

--- a/src/gaia/engine.py
+++ b/src/gaia/engine.py
@@ -137,7 +137,12 @@ class Engine(metaclass=SingletonMeta):
         self.logger.info("Initialising the database")
         from gaia.database import db
         self.db = db
-        self.db.init(self.config.app_config)
+        dict_cfg = {
+            key: getattr(self.config.app_config, key)
+            for key in dir(self.config.app_config)
+            if key.isupper()
+        }
+        self.db.init(dict_cfg)
         self.db.create_all()
 
     def start_database(self) -> None:

--- a/src/gaia/engine.py
+++ b/src/gaia/engine.py
@@ -10,8 +10,7 @@ import typing as t
 from typing import Type
 
 from gaia.config import (
-    configure_logging, EngineConfig, GaiaConfig, get_cache_dir, get_config,
-    get_ecosystem_IDs)
+    configure_logging, EngineConfig, GaiaConfig, get_config, get_ecosystem_IDs)
 from gaia.config.from_files import detach_config
 from gaia.ecosystem import Ecosystem
 from gaia.exceptions import UndefinedParameter
@@ -458,7 +457,7 @@ class Engine(metaclass=SingletonMeta):
     def refresh_chaos(self) -> None:
         for ecosystem in self.ecosystems.values():
             ecosystem.refresh_chaos()
-        chaos_file = get_cache_dir()/"chaos.json"
+        chaos_file = self.config.cache_dir/"chaos.json"
         try:
             with chaos_file.open("r+") as file:
                 ecosystem_chaos = json.loads(file.read())

--- a/src/gaia/hardware/abc.py
+++ b/src/gaia/hardware/abc.py
@@ -16,7 +16,6 @@ from gaia_validators import (
     safe_enum_from_name, HardwareConfig, HardwareLevel, HardwareLevelNames,
     HardwareType, HardwareTypeNames, SensorRecord)
 
-from gaia.config import get_base_dir
 from gaia.dependencies.camera import check_dependencies, Image
 from gaia.hardware.multiplexers import Multiplexer, multiplexer_models
 from gaia.hardware.utils import get_i2c, hardware_logger, is_raspi
@@ -557,7 +556,10 @@ class Camera(Hardware):
     @property
     def camera_dir(self) -> Path:
         if self._camera_dir is None:
-            base_dir = get_base_dir()
+            if self.subroutine is None:
+                base_dir = Path(os.getcwd())
+            else:
+                base_dir = self.subroutine.ecosystem.engine.config.base_dir
             self._camera_dir = base_dir/f"camera/{self.subroutine.ecosystem.name}"
             if not self._camera_dir.exists():
                 os.mkdir(self._camera_dir)

--- a/src/gaia/hardware/actuators/GPIO.py
+++ b/src/gaia/hardware/actuators/GPIO.py
@@ -1,4 +1,3 @@
-from gaia.config import get_config
 from gaia.hardware.abc import gpioDimmer, gpioHardware, Switch
 
 

--- a/src/gaia/hardware/actuators/virtual.py
+++ b/src/gaia/hardware/actuators/virtual.py
@@ -1,4 +1,3 @@
-from gaia import get_config
 from gaia.hardware.abc import gpioDimmer
 from gaia.hardware.actuators.GPIO import gpioSwitch
 from gaia.hardware.virtual import virtualHardware
@@ -8,12 +7,18 @@ from gaia.virtual import get_virtual_ecosystem
 class virtualgpioSwitch(virtualHardware, gpioSwitch):
     def turn_on(self) -> None:
         super().turn_on()
-        if get_config().VIRTUALIZATION:
+        if(
+            self.subroutine is not None
+            and self.subroutine.ecosystem.engine.config.app_config.VIRTUALIZATION
+        ):
             get_virtual_ecosystem(self.subroutine.ecosystem.uid)._light = True
 
     def turn_off(self) -> None:
         super().turn_off()
-        if get_config().VIRTUALIZATION:
+        if(
+            self.subroutine is not None
+            and self.subroutine.ecosystem.engine.config.app_config.VIRTUALIZATION
+        ):
             get_virtual_ecosystem(self.subroutine.ecosystem.uid)._light = False
 
 

--- a/src/gaia/hardware/sensors/virtual.py
+++ b/src/gaia/hardware/sensors/virtual.py
@@ -6,6 +6,7 @@ from gaia.hardware.virtual import virtualHardware
 from gaia.hardware.sensors.GPIO import DHTSensor
 from gaia.hardware.sensors.I2C import (
     AHT20, CapacitiveMoisture, VCNL4040, VEML7700)
+from gaia.virtual import get_virtual_ecosystem
 
 
 if t.TYPE_CHECKING:  # pragma: no cover

--- a/src/gaia/subroutines/chaos.py
+++ b/src/gaia/subroutines/chaos.py
@@ -1,12 +1,10 @@
 from datetime import date, datetime, time, timedelta
 from json.decoder import JSONDecodeError
 from math import pi, sin
-from pathlib import Path
 import typing as t
 import random
 import weakref
 
-from gaia.config import get_cache_dir
 from gaia.utils import json
 
 
@@ -36,8 +34,7 @@ class Chaos:
         self.frequency: int = frequency
         self.duration: int = max_duration
         self.intensity: float = max_intensity
-        base_dir = self.ecosystem.config.general.base_dir
-        self._chaos_file: Path = get_cache_dir()/"chaos.json"
+        self._chaos_file = self.ecosystem.engine.config.cache_dir/"chaos.json"
         self._intensity_function: t.Callable = _intensity_function
         self._time_window: dict[str, datetime] = {}
         self._load_chaos()

--- a/src/gaia/subroutines/health.py
+++ b/src/gaia/subroutines/health.py
@@ -7,7 +7,6 @@ import typing as t
 from gaia_validators import (
     ActuatorMode, ActuatorModePayload, Empty, HealthRecord)
 
-from gaia.config import get_config
 from gaia.dependencies import check_dependencies
 from gaia.hardware import camera_models
 from gaia.hardware.abc import Camera
@@ -30,7 +29,7 @@ class Health(SubroutineTemplate):
         self._finish__init__()
 
     def _start_scheduler(self) -> None:
-        h, m = get_config().HEALTH_LOGGING_TIME.split("h")
+        h, m = self.ecosystem.engine.config.app_config.HEALTH_LOGGING_TIME.split("h")
         scheduler = get_scheduler()
         scheduler.add_job(
             self.health_routine,

--- a/src/gaia/subroutines/light.py
+++ b/src/gaia/subroutines/light.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, time
 from statistics import mean
-from threading import Event, Lock, Thread
+from threading import Event, Thread
 
 from simple_pid import PID
 
@@ -10,7 +10,6 @@ from gaia_validators import (
     ActuatorModePayload, HardwareConfig, HardwareType, LightingHours,
     LightMethod)
 
-from gaia.config import get_config
 from gaia.exceptions import UndefinedParameter
 from gaia.hardware import actuator_models
 from gaia.hardware.abc import Dimmer, Hardware, LightSensor, Switch
@@ -79,7 +78,7 @@ class Light(SubroutineTemplate):
             )
 
     def _light_status_loop(self) -> None:
-        cfg = get_config()
+        cfg = self.ecosystem.engine.config.app_config
         self.logger.info(
             f"Starting light loop at a frequency of {1/cfg.LIGHT_LOOP_PERIOD} Hz")
         while not self._stop_event.is_set():

--- a/src/gaia/subroutines/sensors.py
+++ b/src/gaia/subroutines/sensors.py
@@ -9,7 +9,6 @@ import typing as t
 from gaia_validators import (
     Empty, HardwareConfig, MeasureAverage, SensorsData, SensorsDataDict)
 
-from gaia.config import get_config
 from gaia.hardware import sensor_models
 from gaia.hardware.abc import BaseSensor
 from gaia.subroutines.template import SubroutineTemplate
@@ -26,7 +25,8 @@ class Sensors(SubroutineTemplate):
         self.hardware: dict[str, BaseSensor]
         self._thread: Thread | None = None
         self._stop_event = Event()
-        self._loop_timeout: float = float(get_config().SENSORS_TIMEOUT)
+        self._loop_timeout: float = float(
+            self.ecosystem.engine.config.app_config.SENSORS_TIMEOUT)
         self._sensors_data: SensorsData | Empty = Empty()
         self._data_lock = Lock()
         self._finish__init__()
@@ -93,7 +93,7 @@ class Sensors(SubroutineTemplate):
 
     def add_hardware(self, hardware_config: HardwareConfig) -> BaseSensor:
         model = hardware_config.model
-        if get_config().VIRTUALIZATION:
+        if self.ecosystem.engine.config.app_config.VIRTUALIZATION:
             if not model.startswith("virtual"):
                 hardware_config.model = f"virtual{model}"
         return super().add_hardware(hardware_config)


### PR DESCRIPTION
Allows to call `EngineConfig` with a custom config and use it as the single source of truth. This will make the testings easier.