### PR TITLE
Make the testing suite more resilient to errors

### DIFF
--- a/src/gaia/config/from_files.py
+++ b/src/gaia/config/from_files.py
@@ -254,6 +254,12 @@ class EngineConfig(metaclass=SingletonMeta):
     def app_config(self) -> GaiaConfig:
         return self._app_config
 
+    @app_config.setter
+    def app_config(self, app_config: GaiaConfig) -> None:
+        if not self.app_config.TESTING:
+            raise AttributeError("can't set attribute 'app_config'")
+        self._app_config = app_config
+
     def _get_dir(self, dir_name: str) -> Path:
         try:
             return self._dirs[dir_name]
@@ -519,10 +525,9 @@ class EngineConfig(metaclass=SingletonMeta):
 
     @ecosystems_config_dict.setter
     def ecosystems_config_dict(self, value: dict):
-        if self.app_config.TESTING:
-            self._ecosystems_config_dict = value
-        else:
-            raise AttributeError("Can't set attribute 'ecosystems_config_dict'")
+        if not self.app_config.TESTING:
+            raise AttributeError("can't set attribute 'ecosystems_config_dict'")
+        self._ecosystems_config_dict = value
 
     @property
     def private_config(self) -> dict:
@@ -530,10 +535,9 @@ class EngineConfig(metaclass=SingletonMeta):
 
     @private_config.setter
     def private_config(self, value: dict):
-        if self.app_config.TESTING:
-            self._private_config = value
-        else:
+        if not self.app_config.TESTING:
             raise AttributeError("can't set attribute 'private_config'")
+        self._private_config = value
 
     @property
     def ecosystems_uid(self) -> list[str]:
@@ -643,6 +647,12 @@ class EngineConfig(metaclass=SingletonMeta):
     @property
     def sun_times(self) -> dict[str, SunTimesCacheData]:
         return self._sun_times
+
+    @sun_times.setter
+    def sun_times(self, sun_times: dict[str, SunTimesCacheData]) -> None:
+        if not self.app_config.TESTING:
+            raise AttributeError("can't set attribute 'sun_times'")
+        self._sun_times = sun_times
 
     def get_sun_times(self, place: str) -> gv.SunTimesDict | None:
         sun_times = self.sun_times.get(place)
@@ -853,6 +863,16 @@ class EngineConfig(metaclass=SingletonMeta):
         self.set_sun_times(target, sun_times)
         return True
 
+    @property
+    def chaos_memory(self) -> dict[str, ChaosMemory]:
+        return self._chaos_memory
+
+    @chaos_memory.setter
+    def chaos_memory(self, chaos_memory: dict[str, ChaosMemory]) -> None:
+        if not self.app_config.TESTING:
+            raise AttributeError("can't set attribute 'chaos_memory'")
+        self._chaos_memory = chaos_memory
+
     def _create_chaos_memory(self, ecosystem_uid: str) -> dict[str, ChaosMemory]:
         return {ecosystem_uid: ChaosMemoryValidator().model_dump()}
 
@@ -890,11 +910,11 @@ class EngineConfig(metaclass=SingletonMeta):
         if ecosystem_uid not in self.ecosystems_config_dict:
             raise ValueError(
                 f"No ecosystem with uid '{ecosystem_uid}' found in ecosystems "
-                f"config"
+                f"config."
             )
         if ecosystem_uid not in self._chaos_memory:
             self._chaos_memory.update(self._create_chaos_memory(ecosystem_uid))
-        return self._chaos_memory[ecosystem_uid]
+        return self.chaos_memory[ecosystem_uid]
 
     def get_ecosystem_config(self, ecosystem_id: str) -> "EcosystemConfig":
         return EcosystemConfig(ecosystem_id=ecosystem_id, engine_config=self)
@@ -1058,8 +1078,7 @@ class EcosystemConfig(metaclass=_MetaEcosystemConfig):
     @light_method.setter
     def light_method(self, light_method: gv.LightMethod) -> None:
         if not self.general.app_config.TESTING:
-            raise AttributeError(
-                "'light_method' can only be set when 'TESTING' is True.")
+            raise AttributeError("can't set attribute 'light_method'")
         self.sky["lighting"] = light_method
 
     def set_light_method(self, method: gv.LightMethod) -> None:

--- a/src/gaia/config/from_files.py
+++ b/src/gaia/config/from_files.py
@@ -943,7 +943,7 @@ class _MetaEcosystemConfig(type):
         engine_config = EngineConfig()
         if not engine_config.configs_loaded:
             raise RuntimeError(
-                "Configuration files need to be loaded by `EngineConfig` in"
+                "Configuration files need to be loaded by `EngineConfig` in "
                 "order to get an `EcosystemConfig` instance. To do so, use the "
                 "`EngineConfig().initialize_configs()` method."
             )

--- a/src/gaia/engine.py
+++ b/src/gaia/engine.py
@@ -12,11 +12,8 @@ from apscheduler.executors.pool import BasePoolExecutor
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 
-import gaia_validators as gv
-
 from gaia.config import CacheType, EngineConfig
 from gaia.ecosystem import Ecosystem
-from gaia.exceptions import UndefinedParameter
 from gaia.utils import SingletonMeta
 from gaia.virtual import VirtualWorld
 

--- a/src/gaia/hardware/abc.py
+++ b/src/gaia/hardware/abc.py
@@ -169,7 +169,7 @@ class Address:
 
 
 class _MetaHardware(type):
-    instances: dict[str, "Hardware"] = WeakValueDictionary()
+    instances: WeakValueDictionary[str, "Hardware"] = WeakValueDictionary()
 
     def __call__(cls, *args, **kwargs) -> "Hardware":
         uid = kwargs["uid"]

--- a/src/gaia/hardware/multiplexers.py
+++ b/src/gaia/hardware/multiplexers.py
@@ -15,7 +15,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 
 class _MetaMultiplexer(type):
-    instances: dict[str, "Multiplexer"] = WeakValueDictionary()
+    instances: WeakValueDictionary[str, "Multiplexer"] = WeakValueDictionary()
 
     def __call__(cls, *args, **kwargs) -> "Multiplexer":
         address: int = kwargs["address"]

--- a/src/gaia/subroutines/template.py
+++ b/src/gaia/subroutines/template.py
@@ -5,7 +5,6 @@ from concurrent.futures import ThreadPoolExecutor
 import logging
 import typing as t
 from typing import Type
-import weakref
 
 import gaia_validators as gv
 
@@ -22,7 +21,7 @@ class SubroutineTemplate(ABC):
     def __init__(self, ecosystem: "Ecosystem") -> None:
         """Base class to manage an ecosystem subroutine
         """
-        self._ecosystem: "Ecosystem" = weakref.proxy(ecosystem)
+        self._ecosystem: "Ecosystem" = ecosystem
         self.name: str = self.__class__.__name__.lower()
         eco_name = self._ecosystem.name.replace(" ", "_")
         self.logger: logging.Logger = logging.getLogger(

--- a/src/gaia/utils.py
+++ b/src/gaia/utils.py
@@ -378,7 +378,7 @@ def generate_secret_key_from_password(
 
 
 class SingletonMeta(type):
-    _instances: dict[str, type] = WeakValueDictionary()
+    _instances: WeakValueDictionary[str, type] = WeakValueDictionary()
 
     def __call__(cls, *args, **kwargs):
         try:
@@ -389,5 +389,5 @@ class SingletonMeta(type):
             return instance
 
     @classmethod
-    def detach_instance(cls, cls_name: str):
-        del cls._instances[cls_name]
+    def clear_instances(cls) -> None:
+        cls._instances = WeakValueDictionary()

--- a/src/gaia/utils.py
+++ b/src/gaia/utils.py
@@ -389,5 +389,5 @@ class SingletonMeta(type):
             return instance
 
     @classmethod
-    def clear_instances(cls) -> None:
-        cls._instances = WeakValueDictionary()
+    def detach_instance(cls, cls_name: str):
+        del cls._instances[cls_name]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,9 +113,8 @@ def engine_config(engine_config_master: EngineConfig) -> YieldFixture[EngineConf
         engine_config_master.sun_times = {}
         engine_config_master._executor = ThreadPoolExecutor(
                 thread_name_prefix=f"Engine_ThreadPoolExecutor", max_workers=10)
-
         if engine_config_master.started:
-            raise RuntimeError("EngineConfig watchdog was not stopped.")
+            engine_config_master.stop_watchdog()
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def engine_config(engine_config_master: EngineConfig) -> YieldFixture[EngineConf
                 thread_name_prefix=f"Engine_ThreadPoolExecutor", max_workers=10)
 
         if engine_config_master.started:
-            raise
+            raise RuntimeError("EngineConfig watchdog was not stopped.")
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,8 @@
-from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 import os
 import shutil
 import tempfile
-from typing import Generator, Type, TypeVar
+from typing import Generator, TypeVar
 
 import pytest
 
@@ -11,6 +10,7 @@ import gaia_validators as gv
 
 from gaia.actuator_handler import ActuatorHandler
 from gaia.config import BaseConfig, EcosystemConfig, EngineConfig, GaiaConfigHelper
+from gaia.config.from_files import _MetaEcosystemConfig
 from gaia.ecosystem import Ecosystem
 from gaia.engine import Engine
 from gaia.subroutines import (
@@ -111,8 +111,6 @@ def engine_config(engine_config_master: EngineConfig) -> YieldFixture[EngineConf
         engine_config_master.private_config = {}
         engine_config_master.chaos_memory = {}
         engine_config_master.sun_times = {}
-        engine_config_master._executor = ThreadPoolExecutor(
-                thread_name_prefix=f"Engine_ThreadPoolExecutor", max_workers=10)
         if engine_config_master.started:
             engine_config_master.stop_watchdog()
 
@@ -141,6 +139,7 @@ def ecosystem_config(engine_config: EngineConfig) -> YieldFixture[EcosystemConfi
     try:
         yield ecosystem_config
     finally:
+        del _MetaEcosystemConfig.instances[ecosystem_config.uid]
         del ecosystem_config
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,12 +123,13 @@ def engine(engine_config: EngineConfig) -> YieldFixture[Engine]:
     with get_logs_content(engine_config.logs_dir / "gaia.log"):
         pass  # Clear logs
 
-    yield engine
-
-    if engine.started:
-        engine.stop()
-    SingletonMeta.detach_instance("Engine")
-    del engine
+    try:
+        yield engine
+    finally:
+        if engine.started:
+            engine.stop()
+        SingletonMeta.detach_instance("Engine")
+        del engine
 
 
 @pytest.fixture(scope="function")
@@ -137,9 +138,10 @@ def ecosystem_config(engine_config: EngineConfig) -> YieldFixture[EcosystemConfi
     with get_logs_content(ecosystem_config.general.logs_dir / "gaia.log"):
         pass  # Clear logs
 
-    yield ecosystem_config
-
-    del ecosystem_config
+    try:
+        yield ecosystem_config
+    finally:
+        del ecosystem_config
 
 
 @pytest.fixture(scope="function")
@@ -148,11 +150,12 @@ def ecosystem(engine: Engine) -> YieldFixture[Ecosystem]:
     with get_logs_content(engine.config.logs_dir / "gaia.log"):
         pass  # Clear logs
 
-    yield ecosystem
-
-    if ecosystem.started:
-        ecosystem.stop()
-    del ecosystem
+    try:
+        yield ecosystem
+    finally:
+        if ecosystem.started:
+            ecosystem.stop()
+        del ecosystem
 
 
 @pytest.fixture(scope="function")
@@ -169,42 +172,46 @@ def climate_subroutine(ecosystem: Ecosystem) -> YieldFixture[Climate]:
         {"day": 25, "night": 20, "hysteresis": 2}
     )
 
-    yield climate_subroutine
-
-    if ecosystem.get_subroutine_status("sensors"):
-        ecosystem.stop_subroutine("sensors")
-    if climate_subroutine.started:
-        climate_subroutine.stop()
+    try:
+        yield climate_subroutine
+    finally:
+        if ecosystem.get_subroutine_status("sensors"):
+            ecosystem.stop_subroutine("sensors")
+        if climate_subroutine.started:
+            climate_subroutine.stop()
 
 
 @pytest.fixture(scope="function")
 def light_subroutine(ecosystem: Ecosystem) -> YieldFixture[Light]:
     light_subroutine: Light = ecosystem.subroutines["light"]
 
-    yield light_subroutine
-
-    if light_subroutine.started:
-        light_subroutine.stop()
+    try:
+        yield light_subroutine
+    finally:
+        if light_subroutine.started:
+            light_subroutine.stop()
 
 
 @pytest.fixture(scope="function")
 def sensors_subroutine(ecosystem: Ecosystem) -> YieldFixture[Sensors]:
     sensor_subroutine: Sensors = ecosystem.subroutines["sensors"]
 
-    yield sensor_subroutine
-
-    if sensor_subroutine.started:
-        sensor_subroutine.stop()
+    try:
+        yield sensor_subroutine
+    finally:
+        if sensor_subroutine.started:
+            sensor_subroutine.stop()
 
 
 @pytest.fixture(scope="function")
 def dummy_subroutine(ecosystem: Ecosystem) -> YieldFixture[Sensors]:
     dummy_subroutine: Sensors = ecosystem.subroutines["dummy"]
 
-    yield dummy_subroutine
-
-    if dummy_subroutine.started:
-        dummy_subroutine.stop()
+    try:
+        yield dummy_subroutine
+    finally:
+        if dummy_subroutine.started:
+            dummy_subroutine.stop()
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,7 @@ def default_testing_cfg(testing_cfg: Type[BaseConfig]) -> YieldFixture[None]:
     yield None
 
     GaiaConfigHelper.reset_config()
+    SingletonMeta.clear_instances()
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -108,7 +109,6 @@ def engine_config(default_testing_cfg: Type[None]) -> YieldFixture[EngineConfig]
     if engine_config.started:
         engine_config.stop_watchdog()
     del engine_config
-    SingletonMeta.detach_instance("EngineConfig")
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -122,7 +122,6 @@ def engine(engine_config: EngineConfig) -> YieldFixture[Engine]:
     if engine.started:
         engine.stop()
     del engine
-    SingletonMeta.detach_instance("Engine")
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,8 +94,6 @@ def engine_config_master(testing_cfg: None) -> YieldFixture[EngineConfig]:
 
     yield engine_config
 
-    SingletonMeta.clear_instances()
-
 
 @pytest.fixture(scope="function", autouse=True)
 def engine_config(engine_config_master: EngineConfig) -> YieldFixture[EngineConfig]:
@@ -130,6 +128,7 @@ def engine(engine_config: EngineConfig) -> YieldFixture[Engine]:
 
     if engine.started:
         engine.stop()
+    SingletonMeta.detach_instance("Engine")
     del engine
 
 

--- a/tests/data.py
+++ b/tests/data.py
@@ -16,8 +16,8 @@ sensor_info = {
     "name": "VirtualSensor",
     "address": hardware_address,
     "model": "virtualDHT22",
-    "type": "sensor",
-    "level": "environment",
+    "type": gv.HardwareType.sensor,
+    "level": gv.HardwareLevel.environment,
     "measures": ["temperature", "humidity"],
     "plants": [],
 }
@@ -28,8 +28,8 @@ light_info = {
     "name": "VirtualLight",
     "address": "GPIO_5:GPIO_13",
     "model": "gpioDimmable",
-    "type": "light",
-    "level": "environment",
+    "type": gv.HardwareType.light,
+    "level": gv.HardwareLevel.environment,
     "measures": [],
     "plants": [],
 }
@@ -40,8 +40,8 @@ heater_info = {
     "name": "VirtualHeater",
     "address": "GPIO_26:GPIO_12",
     "model": "gpioDimmable",
-    "type": "heater",
-    "level": "environment",
+    "type": gv.HardwareType.heater,
+    "level": gv.HardwareLevel.environment,
     "measures": [],
     "plants": [],
 }

--- a/tests/subroutines/test_light.py
+++ b/tests/subroutines/test_light.py
@@ -78,11 +78,6 @@ def test_add_hardware(light_subroutine: Light, engine_config: EngineConfig):
         assert "not in the list of the hardware available." in logs
 
 
-def test_lighting_hours(light_subroutine: Light):
-    assert light_subroutine.config.lighting_hours == gv.LightingHours(
-        morning_start=lighting_start, evening_end=lighting_stop)
-
-
 def test_turn_light(light_subroutine: Light):
     with pytest.raises(RuntimeError, match=r"Light subroutine is not started"):
         light_subroutine.turn_light(gv.ActuatorModePayload.on)

--- a/tests/test_actuator_handler.py
+++ b/tests/test_actuator_handler.py
@@ -97,7 +97,6 @@ def test_timer(light_handler: ActuatorHandler):
     assert light_handler.countdown is None
 
 
-@pytest.mark.skip
 def test_turn_to(light_handler: ActuatorHandler):
     ecosystem = light_handler.ecosystem
     hardware = ecosystem.subroutines["light"].hardware

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,7 +112,6 @@ def test_refresh_suntimes_not_needed(engine_config: EngineConfig):
     assert engine_config.home_sun_times is None
 
 
-# TODO: add a cache to be sure data is not downloaded again
 @pytest.mark.skipif(is_not_connected)
 def test_refresh_suntimes_success(
         engine_config: EngineConfig,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -9,8 +9,8 @@ from sqlalchemy import select
 import gaia_validators as gv
 from sqlalchemy_wrapper import SQLAlchemyWrapper
 
+from gaia import EngineConfig
 from gaia.database import db as gaia_db
-from gaia.config import GaiaConfig
 from gaia.database.models import SensorBuffer, SensorRecord
 
 from .data import ecosystem_uid, sensor_uid
@@ -27,11 +27,10 @@ def generate_sensor_data(timestamp: datetime | None = None) -> dict:
 
 
 @pytest.fixture(scope="session")
-def db(testing_cfg: Type[GaiaConfig]) -> SQLAlchemyWrapper:
-    cfg = testing_cfg()
+def db(engine_config_master: EngineConfig) -> SQLAlchemyWrapper:
     dict_cfg = {
-        key: getattr(cfg, key)
-        for key in dir(cfg)
+        key: getattr(engine_config_master.app_config, key)
+        for key in dir(engine_config_master.app_config)
         if key.isupper()
     }
     gaia_db.init(dict_cfg)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -160,6 +160,7 @@ def test_engine_states(engine: Engine):
         engine.resume()
 
     engine.stop()
+    engine.shutdown()
     with get_logs_content(engine.config.logs_dir / "gaia.log") as logs:
         assert "Shutting down Gaia ..." in logs
     assert not engine.started

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -61,6 +61,10 @@ def test_engine_message_broker(engine: Engine):
     engine.start_message_broker()
     engine.stop_message_broker()
 
+    # Reset the message broker
+    engine.message_broker = None
+    engine.event_handler = None
+
 
 def test_engine_database(engine: Engine):
     assert engine.config.app_config.USE_DATABASE is False
@@ -85,6 +89,9 @@ def test_engine_database(engine: Engine):
     engine.start_database()
     engine.stop_database()
 
+    # Reset the database
+    engine.db = None
+
 
 @pytest.mark.timeout(10)
 def test_engine_plugins(engine: Engine):
@@ -108,6 +115,11 @@ def test_engine_plugins(engine: Engine):
 
     engine.start_plugins()
     engine.stop_plugins()
+
+    # Reset the message broker and the database
+    engine.message_broker = None
+    engine.event_handler = None
+    engine.db = None
 
 
 def test_engine_background_tasks(engine: Engine):

--- a/tests/test_relationship.py
+++ b/tests/test_relationship.py
@@ -5,7 +5,7 @@ def test_relationship(engine_config, engine, ecosystem_config, ecosystem):
     assert engine_config.engine is proxy(engine)
     assert engine.config is engine_config
 
-    assert ecosystem_config.general is proxy(engine_config)
+    assert ecosystem_config.general is engine_config
 
     assert ecosystem.engine is proxy(engine)
     assert ecosystem.config is ecosystem_config


### PR DESCRIPTION
Make sure all tests do no crash after a single test crash due to the reliance on the same underlying objects