### PR TITLE
Make `EcosystemConfig` chaos-related function name more in phase with their return type

### DIFF
--- a/src/gaia/config/from_files.py
+++ b/src/gaia/config/from_files.py
@@ -1186,14 +1186,11 @@ class EcosystemConfig(metaclass=_MetaEcosystemConfig):
                 )
 
     @property
-    def chaos_parameters(self) -> gv.ChaosConfig:
-        try:
-            return gv.ChaosConfig(**self.environment["chaos"])
-        except KeyError:
-            raise UndefinedParameter(f"Chaos as not been set in {self.name}")
+    def chaos_config(self) -> gv.ChaosConfig:
+        return gv.ChaosConfig(**self.environment["chaos"])
 
-    @chaos_parameters.setter
-    def chaos_parameters(self, values: gv.ChaosConfigDict) -> None:
+    @chaos_config.setter
+    def chaos_config(self, values: gv.ChaosConfigDict) -> None:
         """Set chaos parameter
 
         :param values: A dict with the entries 'frequency': int,
@@ -1231,15 +1228,15 @@ class EcosystemConfig(metaclass=_MetaEcosystemConfig):
                 beginning = None
                 end = None
         else:
-            if self.chaos_parameters.frequency:
-                chaos_probability = random.randint(1, self.chaos_parameters.frequency)
+            if self.chaos_config.frequency:
+                chaos_probability = random.randint(1, self.chaos_config.frequency)
             else:
                 chaos_probability = 0
             if chaos_probability == 1:
                 today = datetime.now(timezone.utc).replace(
                     hour=14, minute=0, second=0, microsecond=0)
                 beginning = today
-                end = today + timedelta(days=self.chaos_parameters.duration)
+                end = today + timedelta(days=self.chaos_config.duration)
         chaos_memory["time_window"]["beginning"] = beginning
         chaos_memory["time_window"]["end"] = end
         chaos_memory["last_update"] = date.today()
@@ -1255,7 +1252,14 @@ class EcosystemConfig(metaclass=_MetaEcosystemConfig):
         chaos_start_to_now = (now - beginning).total_seconds() // 60
         chaos_fraction = chaos_start_to_now / chaos_duration
         chaos_radian = chaos_fraction * pi
-        return (sin(chaos_radian) * (self.chaos_parameters.intensity - 1.0)) + 1.0
+        return (sin(chaos_radian) * (self.chaos_config.intensity - 1.0)) + 1.0
+
+    @property
+    def chaos_parameters(self) -> gv.ChaosParameters:
+        return gv.ChaosParameters(**{
+            **self.environment["chaos"],
+            "time_window": self.chaos_time_window,
+        })
 
     @property
     def climate(self) -> dict[gv.ClimateParameterNames, gv.AnonymousClimateConfigDict]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,16 +198,16 @@ def test_ecosystem_chaos(ecosystem_config: EcosystemConfig):
     today = datetime.now(timezone.utc).replace(
         hour=14, minute=0, second=0, microsecond=0)
 
-    assert ecosystem_config.chaos_parameters == gv.ChaosConfig()
+    assert ecosystem_config.chaos_config == gv.ChaosConfig()
 
     with pytest.raises(ValueError):
-        ecosystem_config.chaos_parameters = {"wrong": "value"}
+        ecosystem_config.chaos_config = {"wrong": "value"}
 
     max_intensity = 1.2
     duration = 2
     parameters = {"frequency": 1, "duration": duration, "intensity": max_intensity}
-    ecosystem_config.chaos_parameters = parameters
-    assert ecosystem_config.chaos_parameters == gv.ChaosConfig(**parameters)
+    ecosystem_config.chaos_config = parameters
+    assert ecosystem_config.chaos_config == gv.ChaosConfig(**parameters)
 
     # By default, the newly created cfg has empty chaos time window
     chaos_time_window = ecosystem_config.chaos_time_window


### PR DESCRIPTION
- `EcosystemConfig.chaos_parameters` is now `EcosystemConfig.chaos_config` as it returns a `gaia_validators.ChaosConfig`

- Add `EcosystemConfig.chaos_parameters` that returns a `gaia_validators.ChaosParameters`