### PR TITLE
Use a `Task` for `Events.ping()` rather than rely on the scheduler 

### DIFF
--- a/src/gaia/events.py
+++ b/src/gaia/events.py
@@ -201,10 +201,7 @@ class Events(AsyncEventHandler):
         while True:
             start = monotonic()
             await self.ping()
-            time_taken = monotonic() - start
-            sleep_time = 15 - time_taken
-            if sleep_time < 0:
-                sleep_time = 0.01
+            sleep_time = min(15 - (monotonic() - start), 0.01)
             await asyncio.sleep(sleep_time)
 
     async def on_pong(self) -> None:

--- a/src/gaia/subroutines/light.py
+++ b/src/gaia/subroutines/light.py
@@ -45,10 +45,7 @@ class Light(SubroutineTemplate):
         while True:
             start = monotonic()
             await self.routine()
-            time_taken = monotonic() - start
-            sleep_time = self._loop_period - time_taken
-            if sleep_time < 0:
-                sleep_time = 0.01
+            sleep_time = min(self._loop_period - (monotonic() - start), 0.01)
             await asyncio.sleep(sleep_time)
 
     async def _update_light_actuators(self) -> None:


### PR DESCRIPTION
Due to poor connections, the scheduler can fill the logs with noise