### PR TITLE
Use strong refs to hold references to parent objects

### DIFF
--- a/src/gaia/actuator_handler.py
+++ b/src/gaia/actuator_handler.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 import logging
 import time
 import typing
-import weakref
 
 import gaia_validators as gv
 
@@ -628,7 +627,7 @@ class ActuatorHandler:
 
 class ActuatorHub:
     def __init__(self, ecosystem: "Ecosystem") -> None:
-        self.ecosystem: Ecosystem = weakref.proxy(ecosystem)
+        self.ecosystem: Ecosystem = ecosystem
         self.logger = logging.getLogger(
             f"gaia.engine.{ecosystem.name.replace(' ', '_')}.actuators")
         self._pids: dict[gv.ClimateParameter, HystericalPID] = {}

--- a/src/gaia/config/from_files.py
+++ b/src/gaia/config/from_files.py
@@ -13,7 +13,6 @@ from pathlib import Path
 import random
 import typing as t
 from typing import cast, Type, TypedDict, TypeVar
-import weakref
 from weakref import WeakValueDictionary
 
 from anyio.to_thread import run_sync
@@ -236,8 +235,8 @@ class EngineConfig(metaclass=SingletonMeta):
         raise AttributeError("'engine' has not been set up")
 
     @engine.setter
-    def engine(self, value: "Engine") -> None:
-        self._engine = weakref.proxy(value)
+    def engine(self, value: Engine) -> None:
+        self._engine = value
 
     @property
     def engine_set_up(self) -> bool:

--- a/src/gaia/ecosystem.py
+++ b/src/gaia/ecosystem.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import typing
-import weakref
 
 import gaia_validators as gv
 
@@ -39,7 +38,7 @@ class Ecosystem:
             from gaia import Engine
 
             engine = Engine()
-        self._engine: "Engine" = weakref.proxy(engine)
+        self._engine: Engine = engine
         self._config: EcosystemConfig = \
             self.engine.config.get_ecosystem_config(ecosystem_id)
         self._uid: str = self.config.uid

--- a/src/gaia/events.py
+++ b/src/gaia/events.py
@@ -12,7 +12,6 @@ from time import monotonic
 import typing as t
 from typing import Any, Callable, cast, Literal, NamedTuple, Type
 from uuid import UUID
-import weakref
 
 from pydantic import ValidationError
 
@@ -118,7 +117,7 @@ class Events(AsyncEventHandler):
     def __init__(self, engine: Engine, **kwargs) -> None:
         kwargs["namespace"] = "aggregator"
         super().__init__(**kwargs)
-        self.engine: Engine = weakref.proxy(engine)
+        self.engine: Engine = engine
         self.ecosystems: dict[str, "Ecosystem"] = self.engine.ecosystems
         self.registered = False
         self._resent_initialization_data: bool = False

--- a/src/gaia/hardware/abc.py
+++ b/src/gaia/hardware/abc.py
@@ -257,8 +257,7 @@ class Hardware(metaclass=_MetaHardware):
         if subroutine is None:
             self._subroutine = None
         else:
-            # TODO: use weakref again ?
-            self._subroutine = subroutine  # weakref.proxy(subroutine)
+            self._subroutine = subroutine
         self._uid: str = uid
         self._name: str = name
         self._level: gv.HardwareLevel = level

--- a/tests/test_relationship.py
+++ b/tests/test_relationship.py
@@ -1,11 +1,8 @@
-from weakref import proxy
-
-
 def test_relationship(engine_config, engine, ecosystem_config, ecosystem):
-    assert engine_config.engine is proxy(engine)
+    assert engine_config.engine is engine
     assert engine.config is engine_config
 
     assert ecosystem_config.general is engine_config
 
-    assert ecosystem.engine is proxy(engine)
+    assert ecosystem.engine is engine
     assert ecosystem.config is ecosystem_config


### PR DESCRIPTION
- Example: `Ecosystem` instances now use a strong ref to `Engine` instance