### PR TITLE
Parametrize subroutine tests with per-test hardware configs

### DIFF
--- a/src/gaia/config/from_files.py
+++ b/src/gaia/config/from_files.py
@@ -509,6 +509,12 @@ class EngineConfig(metaclass=SingletonMeta):
                 f"ERROR msg: `{e.__class__.__name__}: {e}`"
             )
 
+    @staticmethod
+    def _validate_ecosystem_dict(
+            ecosystem_dict: dict[str, EcosystemConfigDict],
+    ) -> dict[str, EcosystemConfigDict]:
+        return validate_from_root_model(ecosystem_dict, RootEcosystemsConfigValidator)
+
     def _validate_ecosystems_logic(
             self, ecosystem_configs: dict[str, EcosystemConfigDict],
     ) -> dict[str, EcosystemConfigDict]:
@@ -569,7 +575,7 @@ class EngineConfig(metaclass=SingletonMeta):
         checksum = await self._checksum_tracker.compute(config_path)
         # Validate the data structure
         try:
-            validated = validate_from_root_model(unvalidated, RootEcosystemsConfigValidator)
+            validated = self._validate_ecosystem_dict(unvalidated)
         except pydantic.ValidationError as e:  # pragma: no cover
             self.logger.error(
                 f"Could not load ecosystems configuration file. "
@@ -586,6 +592,10 @@ class EngineConfig(metaclass=SingletonMeta):
         for ecosystem_config in self.ecosystems_config.values():
             ecosystem_config.reset_caches()
 
+    @staticmethod
+    def _validate_private_dict(private_dict: PrivateConfigDict) -> PrivateConfigDict:
+        return PrivateConfigValidator(**private_dict).model_dump()
+
     async def _load_private_config(self) -> None:
         # /!\ must be used with the config_files_lock acquired
         self._check_files_lock_acquired()
@@ -595,7 +605,7 @@ class EngineConfig(metaclass=SingletonMeta):
         checksum = await self._checksum_tracker.compute(config_path)
         # Validate the data structure
         try:
-            validated = PrivateConfigValidator(**unvalidated).model_dump()
+            validated = self._validate_private_dict(unvalidated)
         except pydantic.ValidationError as e:  # pragma: no cover
             self.logger.error(
                 f"Could not validate private configuration file. "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from gaia.hardware.abc import _MetaHardware
 from gaia.utils import get_yaml, SingletonMeta
 from gaia.virtual import VirtualWorld, VirtualEcosystem
 
-from .data import ecosystem_info, ecosystem_uid, engine_uid
+from .data import ecosystem_uid, engine_uid, get_ecosystem_info
 from .utils import MockDispatcher, yield_control
 
 
@@ -34,6 +34,7 @@ AsyncYieldFixture = AsyncGenerator[T, None]
 def temp_dir() -> YieldFixture[str]:
     yaml = get_yaml()
     temp_dir = tempfile.mkdtemp(prefix="gaia-")
+    ecosystem_info = get_ecosystem_info()
     with open(os.path.join(temp_dir, "ecosystems.cfg"), "w") as file:
         yaml.dump(ecosystem_info, file)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,10 +157,19 @@ async def ecosystem_config(
 
 @pytest_asyncio.fixture(scope="function")
 async def ecosystem(
+        request: pytest.FixtureRequest,
         engine: Engine,
         caplog: pytest.LogCaptureFixture,
 ) -> AsyncYieldFixture[Ecosystem]:
+    param = getattr(request, "param", {})
+    hardware_dict = param.get("hardware")
+    plants_dict = param.get("plants")
+    ecosystems_dict = get_ecosystem_info(hardware_dict, plants_dict)
+    ecosystems_dict = engine.config._validate_ecosystem_dict(ecosystems_dict)
+    engine.config._ecosystems_config_dict = ecosystems_dict
+
     await engine.initialize_ecosystems()
+
     ecosystem = engine.get_ecosystem(ecosystem_uid)
     ecosystem.virtual_self.start()
     await ecosystem.initialize_hardware()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import tempfile
 from time import monotonic
-from typing import Generator, TypeVar
+from typing import AsyncGenerator, Generator, TypeVar
 
 import pytest
 import pytest_asyncio
@@ -27,6 +27,7 @@ from .utils import MockDispatcher, yield_control
 T = TypeVar("T")
 
 YieldFixture = Generator[T, None, None]
+AsyncYieldFixture = AsyncGenerator[T, None]
 
 
 @pytest.fixture(scope="session")
@@ -68,7 +69,7 @@ def testing_cfg(temp_dir) -> None:
 
 
 @pytest_asyncio.fixture(scope="session", autouse=True)
-async def engine_config_master(testing_cfg: None) -> YieldFixture[EngineConfig]:
+async def engine_config_master(testing_cfg: None) -> AsyncYieldFixture[EngineConfig]:
     engine_config = EngineConfig()
     await engine_config.initialize_configs()
 
@@ -76,7 +77,10 @@ async def engine_config_master(testing_cfg: None) -> YieldFixture[EngineConfig]:
 
 
 @pytest_asyncio.fixture(scope="function", autouse=True)
-async def engine_config(engine_config_master: EngineConfig, caplog: pytest.LogCaptureFixture) -> YieldFixture[EngineConfig]:
+async def engine_config(
+        engine_config_master: EngineConfig,
+        caplog: pytest.LogCaptureFixture,
+) -> AsyncYieldFixture[EngineConfig]:
     app_config = deepcopy(engine_config_master.app_config)
     ecosystem_config = deepcopy(engine_config_master.ecosystems_config_dict)
     private_config = deepcopy(engine_config_master.private_config)
@@ -103,7 +107,10 @@ async def engine_config(engine_config_master: EngineConfig, caplog: pytest.LogCa
 
 
 @pytest_asyncio.fixture(scope="function")
-async def engine(engine_config: EngineConfig, caplog: pytest.LogCaptureFixture) -> YieldFixture[Engine]:
+async def engine(
+        engine_config: EngineConfig,
+        caplog: pytest.LogCaptureFixture,
+) -> AsyncYieldFixture[Engine]:
     engine = await Engine.initialize(engine_config=engine_config)
 
     caplog.clear()
@@ -128,12 +135,15 @@ async def engine(engine_config: EngineConfig, caplog: pytest.LogCaptureFixture) 
 
 
 @pytest_asyncio.fixture(scope="function")
-async def virtual_world(engine: Engine) -> YieldFixture[VirtualWorld]:
+async def virtual_world(engine: Engine) -> AsyncYieldFixture[VirtualWorld]:
     yield engine.virtual_world
 
 
 @pytest_asyncio.fixture(scope="function")
-async def ecosystem_config(engine_config: EngineConfig, caplog: pytest.LogCaptureFixture) -> YieldFixture[EcosystemConfig]:
+async def ecosystem_config(
+        engine_config: EngineConfig,
+        caplog: pytest.LogCaptureFixture,
+) -> AsyncYieldFixture[EcosystemConfig]:
     ecosystem_config = engine_config.get_ecosystem_config(ecosystem_uid)
 
     caplog.clear()
@@ -145,7 +155,10 @@ async def ecosystem_config(engine_config: EngineConfig, caplog: pytest.LogCaptur
 
 
 @pytest_asyncio.fixture(scope="function")
-async def ecosystem(engine: Engine, caplog: pytest.LogCaptureFixture) -> YieldFixture[Ecosystem]:
+async def ecosystem(
+        engine: Engine,
+        caplog: pytest.LogCaptureFixture,
+) -> AsyncYieldFixture[Ecosystem]:
     await engine.initialize_ecosystems()
     ecosystem = engine.get_ecosystem(ecosystem_uid)
     ecosystem.virtual_self.start()
@@ -163,13 +176,13 @@ async def ecosystem(engine: Engine, caplog: pytest.LogCaptureFixture) -> YieldFi
 
 
 @pytest_asyncio.fixture(scope="function")
-async def virtual_ecosystem(ecosystem: Ecosystem) -> YieldFixture[VirtualEcosystem]:
+async def virtual_ecosystem(ecosystem: Ecosystem) -> AsyncYieldFixture[VirtualEcosystem]:
     ecosystem.virtual_self.time_between_measures = -1
     yield ecosystem.virtual_self
 
 
 @pytest_asyncio.fixture(scope="function")
-async def light_handler(ecosystem: Ecosystem) -> YieldFixture[ActuatorHandler]:
+async def light_handler(ecosystem: Ecosystem) -> AsyncYieldFixture[ActuatorHandler]:
     # We need to hold the pid associated to light handler
     pid = ecosystem.actuator_hub.get_pid(gv.ClimateParameter.light)
     light_handler: ActuatorHandler = ecosystem.get_actuator_handler("light")
@@ -192,7 +205,7 @@ def mock_dispatcher_module()  -> MockDispatcher:
 async def mock_dispatcher(
         mock_dispatcher_module: MockDispatcher,
         engine: Engine,
-) -> YieldFixture[MockDispatcher]:
+) -> AsyncYieldFixture[MockDispatcher]:
     engine.config.app_config.COMMUNICATE_WITH_OURANOS = True
     engine.message_broker = mock_dispatcher_module
     await engine.start_message_broker()
@@ -209,7 +222,7 @@ async def mock_dispatcher(
 async def events_handler(
         ecosystem: Ecosystem,
         mock_dispatcher: MockDispatcher,
-) -> YieldFixture[Events]:
+) -> AsyncYieldFixture[Events]:
     events_handler = Events(ecosystem.engine)
     mock_dispatcher.register_event_handler(events_handler)
     ecosystem.engine.event_handler = events_handler
@@ -223,7 +236,7 @@ async def events_handler(
 @pytest_asyncio.fixture(scope="function")
 async def registered_events_handler(
         events_handler: Events,
-) -> YieldFixture[Events]:
+) -> AsyncYieldFixture[Events]:
     events_handler._last_heartbeat = monotonic()
     assert events_handler.is_connected()
     events_handler.registered = True

--- a/tests/data.py
+++ b/tests/data.py
@@ -35,14 +35,14 @@ i2c_sensor_veml7700_uid = "xWQ9uF1bplKs0nk7"
 i2c_sensor_veml7700_info: gv.AnonymousHardwareConfigDict = {
     "name": "VirtualI2CSensor_VEML7700",
     "active": True,
-    "address": "I2C_0x70#0@default",
+    "address": "I2C_default",
     "model": "virtualVEML7700",
     "type": gv.HardwareType.sensor,
     "level": gv.HardwareLevel.environment,
 #    "groups": None,
     "measures": ["light"],
 #    "plants": [],
-    "multiplexer_model": "TCA9548A",
+#    "multiplexer_model": None,
 }
 
 

--- a/tests/data.py
+++ b/tests/data.py
@@ -274,7 +274,10 @@ weather_cfg: dict[str, gv.AnonymousWeatherConfigDict] = {
 }
 
 
-def get_ecosystem_info():
+def get_ecosystem_info(
+        hardware_dict: dict | None = None,
+        plants_dict: dict | None = None,
+):
     return {
         ecosystem_uid: {
             "name": ecosystem_name,
@@ -303,7 +306,7 @@ def get_ecosystem_info():
                 "climate": climate_dict,
                 "weather": weather_cfg,
             },
-            "IO": IO_dict,
-            "plants": {},
+            "hardware": hardware_dict or IO_dict,
+            "plants": plants_dict or {},
         },
     }

--- a/tests/data.py
+++ b/tests/data.py
@@ -274,35 +274,36 @@ weather_cfg: dict[str, gv.AnonymousWeatherConfigDict] = {
 }
 
 
-ecosystem_info = {
-    ecosystem_uid: {
-        "name": ecosystem_name,
-        "status": False,
-        "management": {
-            "sensors": False,
-            "light": False,
-            "climate": False,
-            "watering": False,
-            "health": False,
-            "alarms": False,
-            "pictures": False,
-            "database": False,
-        },
-        "environment": {
-            "chaos": {
-                "frequency": 0,
-                "duration": 0,
-                "intensity": 0.0,
+def get_ecosystem_info():
+    return {
+        ecosystem_uid: {
+            "name": ecosystem_name,
+            "status": False,
+            "management": {
+                "sensors": False,
+                "light": False,
+                "climate": False,
+                "watering": False,
+                "health": False,
+                "alarms": False,
+                "pictures": False,
+                "database": False,
             },
-            "nycthemeral_cycle": {
-                "day": lighting_start,
-                "night": lighting_stop,
-                "lighting": lighting_method,
+            "environment": {
+                "chaos": {
+                    "frequency": 0,
+                    "duration": 0,
+                    "intensity": 0.0,
+                },
+                "nycthemeral_cycle": {
+                    "day": lighting_start,
+                    "night": lighting_stop,
+                    "lighting": lighting_method,
+                },
+                "climate": climate_dict,
+                "weather": weather_cfg,
             },
-            "climate": climate_dict,
-            "weather": weather_cfg,
+            "IO": IO_dict,
+            "plants": {},
         },
-        "IO": IO_dict,
-        "plants": {},
-    },
-}
+    }

--- a/tests/subroutines/conftest.py
+++ b/tests/subroutines/conftest.py
@@ -37,14 +37,7 @@ async def sensors_subroutine(ecosystem: Ecosystem) -> YieldFixture[Sensors]:
 
 # Subroutines needing sensors subroutine
 @pytest_asyncio.fixture(scope="function")
-async def light_subroutine(
-        ecosystem: Ecosystem,
-        sensors_subroutine: Sensors,
-) -> YieldFixture[Light]:
-    # Sensors subroutine is required for full routine
-    sensors_subroutine.enable()
-    await sensors_subroutine.start()
-
+async def light_subroutine(ecosystem: Ecosystem) -> YieldFixture[Light]:
     light_subroutine: Light = ecosystem.get_subroutine("light")
 
     async with auto_clean(light_subroutine) as subroutine:

--- a/tests/subroutines/conftest.py
+++ b/tests/subroutines/conftest.py
@@ -1,6 +1,5 @@
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, TypeVar
-from unittest.mock import patch
 
 import pytest_asyncio
 

--- a/tests/subroutines/test_climate.py
+++ b/tests/subroutines/test_climate.py
@@ -9,10 +9,19 @@ from gaia import Ecosystem
 from gaia.subroutines.sensors import Sensors
 from gaia.subroutines.climate import Climate
 
-from .. import data
+from tests import data as test_data
+
+
+climate_dict = {
+    test_data.sensor_uid: test_data.sensor_info,  # DHT22 for temperature and humidity measures
+    test_data.heater_uid: test_data.heater_info,
+    test_data.humidifier_uid: test_data.humidifier_info,
+    test_data.ws_dimmer_uid: test_data.ws_dimmer_info,  # dehumidifier
+}
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("ecosystem", [{"hardware": climate_dict}], indirect=True)
 class TestClimateSubroutine:
     async def test_manageable(self, ecosystem: Ecosystem, climate_subroutine: Climate):
         # Save config
@@ -36,7 +45,7 @@ class TestClimateSubroutine:
         assert climate_subroutine.manageable
 
         # Make sure a regulator is needed
-        climate_subroutine.ecosystem.config.delete_hardware(data.heater_uid)
+        climate_subroutine.ecosystem.config.delete_hardware(test_data.heater_uid)
         await ecosystem.refresh_hardware()
         assert not climate_subroutine.manageable
 
@@ -46,21 +55,20 @@ class TestClimateSubroutine:
     async def test_target(self, climate_subroutine: Climate):
         day = time(hour=12)
         target = climate_subroutine.compute_target(gv.ClimateParameter.temperature, day)
-        assert target[0] == data.temperature_cfg["day"]
-        assert target[1] == data.temperature_cfg["hysteresis"]
+        assert target[0] == test_data.temperature_cfg["day"]
+        assert target[1] == test_data.temperature_cfg["hysteresis"]
 
         night = time(hour=22)
         target = climate_subroutine.compute_target(gv.ClimateParameter.temperature, night)
-        assert target[0] == data.temperature_cfg["night"]
-        assert target[1] == data.temperature_cfg["hysteresis"]
+        assert target[0] == test_data.temperature_cfg["night"]
+        assert target[1] == test_data.temperature_cfg["hysteresis"]
 
     async def test_hardware_needed(self, climate_subroutine: Climate):
         uids = climate_subroutine.get_hardware_needed_uid()
         assert uids == {
-            data.ws_dimmer_uid,
-            data.heater_uid,
-            data.humidifier_uid,
-            data.ws_switch_uid,
+            test_data.heater_uid,
+            test_data.humidifier_uid,
+            test_data.ws_dimmer_uid,
         }
 
     async def test_expected_actuators(self, climate_subroutine: Climate):

--- a/tests/subroutines/test_health.py
+++ b/tests/subroutines/test_health.py
@@ -6,7 +6,7 @@ from gaia import Ecosystem
 from gaia.hardware.abc import Measure
 from gaia.subroutines import Health, Light
 
-import tests.data as test_data
+from tests import data as test_data
 
 
 health_dict = {

--- a/tests/subroutines/test_health.py
+++ b/tests/subroutines/test_health.py
@@ -6,30 +6,37 @@ from gaia import Ecosystem
 from gaia.hardware.abc import Measure
 from gaia.subroutines import Health, Light
 
-from ..data import camera_uid
+import tests.data as test_data
+
+
+health_dict = {
+    test_data.light_uid: test_data.light_info,
+    test_data.camera_uid: test_data.camera_info,
+}
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("ecosystem", [{"hardware": health_dict}], indirect=True)
 class TestHealthSubroutine:
     async def test_manageable(self, ecosystem: Ecosystem, health_subroutine: Health):
-        camera_cfg = health_subroutine.config.hardware_dict[camera_uid].copy()
+        camera_cfg = health_subroutine.config.hardware_dict[test_data.camera_uid].copy()
         assert health_subroutine.manageable
 
-        health_subroutine.config.hardware_dict[camera_uid]["measures"] = []
+        health_subroutine.config.hardware_dict[test_data.camera_uid]["measures"] = []
         await ecosystem.refresh_hardware()
         assert not health_subroutine.manageable
 
-        health_subroutine.config.hardware_dict[camera_uid] = camera_cfg
+        health_subroutine.config.hardware_dict[test_data.camera_uid] = camera_cfg
         await ecosystem.refresh_hardware()
         assert health_subroutine.manageable
 
-        health_subroutine.config.delete_hardware(camera_uid)
+        health_subroutine.config.delete_hardware(test_data.camera_uid)
         await ecosystem.refresh_hardware()
         assert not health_subroutine.manageable
 
     async def test_hardware_needed(self, health_subroutine: Health):
         uids = health_subroutine.get_hardware_needed_uid()
-        assert uids == {camera_uid}
+        assert uids == {test_data.camera_uid}
 
     async def test_routine(self, health_subroutine: Health):
         # Enable the subroutine
@@ -78,7 +85,7 @@ class TestHealthSubroutine:
         health_subroutine.enable()
         await health_subroutine.start()
 
-        camera = health_subroutine.hardware[camera_uid]
+        camera = health_subroutine.hardware[test_data.camera_uid]
 
         image = await camera.get_image()
         index = health_subroutine._get_index(image, Measure.mpri)

--- a/tests/subroutines/test_light.py
+++ b/tests/subroutines/test_light.py
@@ -5,7 +5,7 @@ import pytest
 import gaia_validators as gv
 
 from gaia import Ecosystem
-from gaia.subroutines import Light
+from gaia.subroutines import Light, Sensors
 
 from tests import data as test_data
 
@@ -80,7 +80,11 @@ class TestLightSubroutine:
         with pytest.raises(ValueError):
             await light_subroutine.turn_light("WrongMode")
 
-    async def test_routine(self, light_subroutine: Light):
+    async def test_routine(self, sensors_subroutine: Sensors, light_subroutine: Light):
+        # Sensors subroutine is required for full routine
+        sensors_subroutine.enable()
+        await sensors_subroutine.start()
+
         # Enable the subroutines
         light_subroutine.enable()
 

--- a/tests/subroutines/test_light.py
+++ b/tests/subroutines/test_light.py
@@ -7,15 +7,22 @@ import gaia_validators as gv
 from gaia import Ecosystem
 from gaia.subroutines import Light
 
-from ..data import light_uid
+from tests import data as test_data
+
+
+light_dict = {
+    test_data.i2c_sensor_veml7700_uid: test_data.i2c_sensor_veml7700_info,
+    test_data.light_uid: test_data.light_info,
+}
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("ecosystem", [{"hardware": light_dict}], indirect=True)
 class TestLightSubroutine:
     async def test_manageable(self, ecosystem: Ecosystem, light_subroutine: Light):
         assert light_subroutine.manageable
 
-        ecosystem.config.delete_hardware(light_uid)
+        ecosystem.config.delete_hardware(test_data.light_uid)
         await ecosystem.refresh_hardware()
 
         assert not light_subroutine.manageable
@@ -58,7 +65,7 @@ class TestLightSubroutine:
 
     async def test_hardware_needed(self, light_subroutine: Light):
         uids = light_subroutine.get_hardware_needed_uid()
-        assert uids == {light_uid}
+        assert uids == {test_data.light_uid}
 
     async def test_turn_light(self, light_subroutine: Light):
         with pytest.raises(RuntimeError, match=r"Light subroutine is not started"):

--- a/tests/subroutines/test_pictures.py
+++ b/tests/subroutines/test_pictures.py
@@ -3,10 +3,16 @@ import pytest
 from gaia import Ecosystem
 from gaia.subroutines import Pictures
 
-from ..data import camera_uid
+import tests.data as test_data
+
+
+pictures_dict = {
+    test_data.camera_uid: test_data.camera_info,
+}
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("ecosystem", [{"hardware": pictures_dict}], indirect=True)
 class TestPictureSubroutine:
     async def test_manageable(
             self,
@@ -15,14 +21,14 @@ class TestPictureSubroutine:
     ):
         assert pictures_subroutine.manageable
 
-        ecosystem.config.delete_hardware(camera_uid)
+        ecosystem.config.delete_hardware(test_data.camera_uid)
         await ecosystem.refresh_hardware()
 
         assert not pictures_subroutine.manageable
 
     async def test_hardware_needed(self, pictures_subroutine: Pictures):
         uids = pictures_subroutine.get_hardware_needed_uid()
-        assert uids == {camera_uid}
+        assert uids == {test_data.camera_uid}
 
     async def test_routine(self, pictures_subroutine: Pictures):
         # Enable the subroutine

--- a/tests/subroutines/test_pictures.py
+++ b/tests/subroutines/test_pictures.py
@@ -3,7 +3,7 @@ import pytest
 from gaia import Ecosystem
 from gaia.subroutines import Pictures
 
-import tests.data as test_data
+from tests import data as test_data
 
 
 pictures_dict = {

--- a/tests/subroutines/test_sensors.py
+++ b/tests/subroutines/test_sensors.py
@@ -26,7 +26,7 @@ class TestSensorsSubroutine:
 
     async def test_hardware_needed(self, sensors_subroutine: Sensors):
         uids = sensors_subroutine.get_hardware_needed_uid()
-        assert uids == {test_data.sensor_uid, }
+        assert uids == {test_data.sensor_uid}
 
     async def test_routine(self, sensors_subroutine: Sensors):
         # Rely on the correct implementation of virtualDHT22

--- a/tests/subroutines/test_sensors.py
+++ b/tests/subroutines/test_sensors.py
@@ -5,11 +5,14 @@ import gaia_validators as gv
 from gaia import Ecosystem
 from gaia.subroutines import Sensors
 
-from ..data import (
-    i2c_sensor_ens160_uid, i2c_sensor_veml7700_uid, sensor_uid, ws_sensor_uid)
+from tests import data as test_data
+
+
+sensors_dict = {test_data.sensor_uid: test_data.sensor_info}
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("ecosystem", [{"hardware": sensors_dict}], indirect=True)
 class TestSensorsSubroutine:
     async def test_manageable(self, ecosystem: Ecosystem, sensors_subroutine: Sensors):
         assert sensors_subroutine.manageable
@@ -23,12 +26,7 @@ class TestSensorsSubroutine:
 
     async def test_hardware_needed(self, sensors_subroutine: Sensors):
         uids = sensors_subroutine.get_hardware_needed_uid()
-        assert uids == {
-            i2c_sensor_ens160_uid,
-            i2c_sensor_veml7700_uid,
-            sensor_uid,
-            ws_sensor_uid,
-        }
+        assert uids == {test_data.sensor_uid, }
 
     async def test_routine(self, sensors_subroutine: Sensors):
         # Rely on the correct implementation of virtualDHT22

--- a/tests/subroutines/test_weather.py
+++ b/tests/subroutines/test_weather.py
@@ -8,10 +8,16 @@ from gaia import Ecosystem
 from gaia.actuator_handler import Timer
 from gaia.subroutines.weather import Weather
 
-from ..data import humidifier_uid
+from tests import data as test_data
+
+
+weather_dict = {
+    test_data.humidifier_uid: test_data.humidifier_info,
+}
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("ecosystem", [{"hardware": weather_dict}], indirect=True)
 class TestWeatherSubroutine:
     async def test_manageable(self, ecosystem: Ecosystem, weather_subroutine: Weather):
         assert weather_subroutine.manageable
@@ -26,13 +32,13 @@ class TestWeatherSubroutine:
         assert weather_subroutine.manageable
 
         # Make sure a hardware belonging to the group is needed
-        ecosystem.config.delete_hardware(humidifier_uid)
+        ecosystem.config.delete_hardware(test_data.humidifier_uid)
         await ecosystem.refresh_hardware()
         assert not weather_subroutine.manageable
 
     def test_hardware_needed(self, weather_subroutine: Weather):
         uids = weather_subroutine.get_hardware_needed_uid()
-        assert uids == {humidifier_uid}
+        assert uids == {test_data.humidifier_uid}
 
     async def test_routine(self, weather_subroutine: Weather):
         # Enable the subroutine

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,7 @@ from gaia.subroutines import subroutine_names
 from gaia.utils import get_yaml
 
 from .data import (
-    ecosystem_info, ecosystem_name, humidifier_info, humidifier_uid,
+    ecosystem_name, get_ecosystem_info, humidifier_info, humidifier_uid,
     lighting_method, plant_info, rain_cfg, sensor_info, sensor_uid,
     sun_times, temperature_cfg)
 
@@ -138,6 +138,7 @@ class TestWatchdog:
             engine_config.watchdog.stop()
 
         # Restore config files
+        ecosystem_info = get_ecosystem_info()
         with open(engine_config.gaia_dir / ConfigType.ecosystems.value, "w") as cfg:
             yaml.dump(ecosystem_info, cfg)
         with open(engine_config.gaia_dir / ConfigType.private.value, "w") as cfg:

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -301,7 +301,7 @@ class TestMultiplexer:
             TCA9548A, "_on_check_requirements", classmethod(failing_check))
 
         hardware_cfg = gv.HardwareConfig(
-            **{"uid": f"mux_{i2c_sensor_veml7700_uid}", **IO_dict[i2c_sensor_veml7700_uid]})
+            **{"uid": f"mux_{i2c_sensor_ens160_uid}", **IO_dict[i2c_sensor_ens160_uid]})
         with pytest.raises(RuntimeError, match="multiplexer library missing"):
             await Hardware.initialize(hardware_cfg, ecosystem_uid)
 


### PR DESCRIPTION
Make the `ecosystem` fixture parametrizable so each subroutine test class declares only the hardware (and plants) it actually needs, instead of every test spinning up the full `IO_dict`